### PR TITLE
feat(io): SSE orchestrator transport and enveloped events (#81-84)

### DIFF
--- a/io/api/src/index.ts
+++ b/io/api/src/index.ts
@@ -1,32 +1,90 @@
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
-import type { StatusUpdate, LogEntry, SendMessageRequest } from '@cerberos/io-core';
+import {
+  parseOrchestratorStreamEvent,
+  type StatusUpdate,
+  type LogEntry,
+  type SendMessageRequest,
+  type OrchestratorStreamEvent,
+  type CredentialRequest,
+} from '@cerberos/io-core';
 
 // In-memory storage (would be replaced with proper persistence in production)
 const tasks = new Map<string, StatusUpdate>();
 const logs: LogEntry[] = [];
 
+type SsePush = (bytes: Uint8Array) => void;
+const sseClients = new Map<string, Set<SsePush>>();
+
+const text = new TextEncoder();
+
+function subscribeSse(taskId: string, push: SsePush): () => void {
+  let set = sseClients.get(taskId);
+  if (!set) {
+    set = new Set();
+    sseClients.set(taskId, set);
+  }
+  set.add(push);
+  return () => {
+    set!.delete(push);
+    if (set!.size === 0) sseClients.delete(taskId);
+  };
+}
+
+function broadcastStreamEvent(taskId: string, event: OrchestratorStreamEvent): void {
+  const line = `data: ${JSON.stringify(event)}\n\n`;
+  const bytes = text.encode(line);
+  const set = sseClients.get(taskId);
+  if (!set) return;
+  for (const push of set) {
+    try {
+      push(bytes);
+    } catch {
+      /* client disconnected */
+    }
+  }
+}
+
+function broadcastStatus(taskId: string, status: StatusUpdate): void {
+  broadcastStreamEvent(taskId, { type: 'status', payload: status });
+}
+
+function persistAndBroadcastStatus(status: StatusUpdate): void {
+  tasks.set(status.taskId, status);
+  broadcastStatus(status.taskId, status);
+}
+
+/** Demo credential for local dev when Orchestrator is not wired (task 13 in mock UI). */
+const DEMO_TASK_13_CREDENTIAL: CredentialRequest = {
+  taskId: '13',
+  requestId: 'cred-13-dbpwd',
+  userId: '00000000-0000-0000-0000-000000000001',
+  keyName: 'prod_db_admin_password',
+  label: 'Production database admin password',
+  description: 'Required to execute the migration on the production cluster.',
+};
+
 // Mock response generator for demo
 async function* generateMockResponse(content: string): AsyncGenerator<string> {
   const responses = [
     "I'm analyzing your request",
-    "Processing the information",
-    "Looking up relevant data",
-    "Formulating a response",
+    'Processing the information',
+    'Looking up relevant data',
+    'Formulating a response',
   ];
 
   for (const response of responses) {
-    yield response + "...\n\n";
+    yield response + '...\n\n';
     await new Promise(r => setTimeout(r, 500));
   }
 
   yield `Based on your message "${content}", here's what I found:\n\n`;
   await new Promise(r => setTimeout(r, 300));
 
-  yield "• This is a demo response from the IO API server\n";
-  yield "• The streaming is working correctly\n";
-  yield "• Your message was logged to memory\n";
-  yield "\nFeel free to ask more questions!";
+  yield '• This is a demo response from the IO API server\n';
+  yield '• The streaming is working correctly\n';
+  yield '• Your message was logged to memory\n';
+  yield '\nFeel free to ask more questions!';
 }
 
 const app = new Hono();
@@ -54,9 +112,32 @@ app.get('/api/tasks/:taskId', (c) => {
   return c.json(task);
 });
 
+/**
+ * Orchestrator (or gateway) pushes frames onto the same channel the web UI consumes via SSE.
+ * Body: { type: 'status', payload: StatusUpdate } | { type: 'credential_request', payload: CredentialRequest }
+ */
+app.post('/api/orchestrator/stream-events', async (c) => {
+  let raw: unknown;
+  try {
+    raw = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid json' }, 400);
+  }
+  const event = parseOrchestratorStreamEvent(raw);
+  if (!event) {
+    return c.json({ error: 'invalid orchestrator stream event' }, 400);
+  }
+  const taskId = event.payload.taskId;
+  if (event.type === 'status') {
+    tasks.set(taskId, event.payload);
+  }
+  broadcastStreamEvent(taskId, event);
+  return c.json({ ok: true });
+});
+
 // Send a message (returns streaming response)
 app.post('/api/chat', async (c) => {
-  const body = await c.req.json() as SendMessageRequest;
+  const body = (await c.req.json()) as SendMessageRequest;
   const { taskId, content, conversationHistory } = body;
 
   // Log user message
@@ -68,14 +149,14 @@ app.post('/api/chat', async (c) => {
   };
   logs.push(userLogEntry);
 
-  // Update task status to working
-  tasks.set(taskId, {
+  const workingStatus: StatusUpdate = {
     taskId,
     status: 'working',
     lastUpdate: 'Generating response...',
     expectedNextInputMinutes: 1,
     timestamp: Date.now(),
-  });
+  };
+  persistAndBroadcastStatus(workingStatus);
 
   // Return SSE streaming response
   const encoder = new TextEncoder();
@@ -97,14 +178,14 @@ app.post('/api/chat', async (c) => {
         at: new Date().toISOString(),
       });
 
-      // Update task status
-      tasks.set(taskId, {
+      const doneStatus: StatusUpdate = {
         taskId,
         status: 'awaiting_feedback',
         lastUpdate: 'Response complete',
         expectedNextInputMinutes: 0,
         timestamp: Date.now(),
-      });
+      };
+      persistAndBroadcastStatus(doneStatus);
     },
   });
 
@@ -112,7 +193,7 @@ app.post('/api/chat', async (c) => {
     headers: {
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-cache',
-      'Connection': 'keep-alive',
+      Connection: 'keep-alive',
       'X-Content-Type-Options': 'nosniff',
     },
   });
@@ -133,7 +214,7 @@ app.get('/api/logs', (c) => {
 // Credential submission endpoint (proxies to Memory Vault)
 // NEVER logs or exposes the credential value in responses or logs
 app.post('/api/credential', async (c) => {
-  const body = await c.req.json() as {
+  const body = (await c.req.json()) as {
     taskId: string;
     requestId: string;
     userId: string;
@@ -142,12 +223,10 @@ app.post('/api/credential', async (c) => {
   };
   const { taskId, requestId, userId, keyName, value } = body;
 
-  // Memory vault API URL from environment or default
   const memoryVaultUrl = process.env.MEMORY_VAULT_URL || 'http://localhost:8080/api/v1/vault';
   const memoryApiKey = process.env.MEMORY_VAULT_API_KEY || '';
 
   try {
-    // Forward to Memory's vault endpoint
     const vaultRes = await fetch(`${memoryVaultUrl}/${userId}/secrets`, {
       method: 'POST',
       headers: {
@@ -163,64 +242,89 @@ app.post('/api/credential', async (c) => {
 
     if (!vaultRes.ok) {
       const errText = await vaultRes.text();
-      return c.json({
+      return c.json(
+        {
+          taskId,
+          requestId,
+          keyName,
+          status: 'error',
+          error: `Vault returned ${vaultRes.status}: ${errText}`,
+        },
+        500,
+      );
+    }
+
+    return c.json(
+      {
         taskId,
         requestId,
         keyName,
-        status: 'error',
-        error: `Vault returned ${vaultRes.status}: ${errText}`,
-      }, 500);
-    }
-
-    // Return acknowledgment (no secret material)
-    return c.json({
-      taskId,
-      requestId,
-      keyName,
-      status: 'stored',
-    }, 201);
-  } catch (err) {
-    // Demo mode: Memory service not running, simulate success
+        status: 'stored',
+      },
+      201,
+    );
+  } catch {
     console.log('[credential] Memory service unavailable, simulating credential storage');
-    return c.json({
-      taskId,
-      requestId,
-      keyName,
-      status: 'stored',
-    }, 201);
+    return c.json(
+      {
+        taskId,
+        requestId,
+        keyName,
+        status: 'stored',
+      },
+      201,
+    );
   }
 });
 
-// SSE endpoint for status updates
+// SSE: orchestrator → IO push stream for one task (enveloped events per io-interfaces.md §1.0)
 app.get('/api/events/:taskId', (c) => {
   const taskId = c.req.param('taskId');
 
-  const stream = new ReadableStream({
+  const stream = new ReadableStream<Uint8Array>({
     start(controller) {
-      const encoder = new TextEncoder();
-
-      // Send initial status
-      const status = tasks.get(taskId) || {
-        taskId,
-        status: 'awaiting_feedback' as const,
-        lastUpdate: 'Waiting for input',
-        expectedNextInputMinutes: null,
-        timestamp: Date.now(),
+      const push = (bytes: Uint8Array) => {
+        try {
+          controller.enqueue(bytes);
+        } catch {
+          /* stream closed */
+        }
       };
 
-      controller.enqueue(encoder.encode(`data: ${JSON.stringify(status)}\n\n`));
+      const unsubscribe = subscribeSse(taskId, push);
 
-      // Simulate periodic updates
+      // Only push initial status when the BFF has state (e.g. after /api/chat). Otherwise the
+      // web UI keeps its local mock task list without being overwritten by a synthetic default.
+      const stored = tasks.get(taskId);
+      if (stored) {
+        push(text.encode(`data: ${JSON.stringify({ type: 'status', payload: stored })}\n\n`));
+      }
+
+      // Local dev: push a sample credential request for the demo task
+      if (taskId === '13') {
+        setTimeout(() => {
+          broadcastStreamEvent('13', {
+            type: 'credential_request',
+            payload: DEMO_TASK_13_CREDENTIAL,
+          });
+        }, 900);
+      }
+
       const interval = setInterval(() => {
         const current = tasks.get(taskId);
         if (current?.status === 'working') {
-          controller.enqueue(encoder.encode(`data: ${JSON.stringify(current)}\n\n`));
+          broadcastStatus(taskId, { ...current, timestamp: Date.now() });
         }
-      }, 3000);
+      }, 2800);
 
       c.req.raw.signal.addEventListener('abort', () => {
         clearInterval(interval);
-        controller.close();
+        unsubscribe();
+        try {
+          controller.close();
+        } catch {
+          /* */
+        }
       });
     },
   });
@@ -229,7 +333,7 @@ app.get('/api/events/:taskId', (c) => {
     headers: {
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-cache',
-      'Connection': 'keep-alive',
+      Connection: 'keep-alive',
     },
   });
 });

--- a/io/core/src/types.ts
+++ b/io/core/src/types.ts
@@ -95,6 +95,68 @@ export interface StatusUpdate {
 }
 
 // ============================================
+// Orchestrator → IO push stream (SSE / WebSocket)
+// ============================================
+
+/** One frame on the orchestrator→IO push channel (per task stream). */
+export type OrchestratorStreamEvent =
+  | { type: 'status'; payload: StatusUpdate }
+  | { type: 'credential_request'; payload: CredentialRequest };
+
+function isRecord(x: unknown): x is Record<string, unknown> {
+  return typeof x === 'object' && x !== null;
+}
+
+function isTaskStatus(x: unknown): x is TaskStatus {
+  return x === 'awaiting_feedback' || x === 'working' || x === 'completed';
+}
+
+/** Parse SSE `data:` JSON into a stream event. Supports legacy bare `StatusUpdate` objects. */
+export function parseOrchestratorStreamEvent(raw: unknown): OrchestratorStreamEvent | null {
+  if (!isRecord(raw)) return null;
+
+  if (raw.type === 'status' && isRecord(raw.payload)) {
+    const p = raw.payload;
+    if (
+      typeof p.taskId === 'string' &&
+      isTaskStatus(p.status) &&
+      typeof p.lastUpdate === 'string' &&
+      (p.expectedNextInputMinutes === null || typeof p.expectedNextInputMinutes === 'number')
+    ) {
+      return { type: 'status', payload: p as unknown as StatusUpdate };
+    }
+    return null;
+  }
+
+  if (raw.type === 'credential_request' && isRecord(raw.payload)) {
+    const p = raw.payload;
+    if (
+      typeof p.taskId === 'string' &&
+      typeof p.requestId === 'string' &&
+      typeof p.userId === 'string' &&
+      typeof p.keyName === 'string' &&
+      typeof p.label === 'string' &&
+      (p.description === undefined || typeof p.description === 'string')
+    ) {
+      return { type: 'credential_request', payload: p as unknown as CredentialRequest };
+    }
+    return null;
+  }
+
+  // Legacy: top-level StatusUpdate (no envelope)
+  if (
+    typeof raw.taskId === 'string' &&
+    isTaskStatus(raw.status) &&
+    typeof raw.lastUpdate === 'string' &&
+    (raw.expectedNextInputMinutes === null || typeof raw.expectedNextInputMinutes === 'number')
+  ) {
+    return { type: 'status', payload: raw as unknown as StatusUpdate };
+  }
+
+  return null;
+}
+
+// ============================================
 // Memory / Logging Types
 // ============================================
 

--- a/io/io-interfaces.md
+++ b/io/io-interfaces.md
@@ -6,6 +6,22 @@ This document describes the format and requirements for the **IO component**'s i
 
 ## 1. Orchestrator
 
+### 1.0 Transport (default contract)
+
+Until the Orchestrator team publishes a separate ADR, **IO assumes the following** so integration can proceed in parallel:
+
+| Topic | Default | Notes |
+|-------|---------|--------|
+| **Orchestrator → IO push** | **SSE** (`GET …/api/events/{taskId}`) | One stream per selected task. Each `data:` line is JSON. |
+| **Envelope** | `{ type, payload }` | `type` is `status` or `credential_request`. Avoids ambiguity with legacy bare `StatusUpdate` objects (still accepted when parsing). |
+| **IO → Orchestrator chat** | `POST …/api/chat` | Request body: `SendMessageRequest`. Response: **SSE** with `{ chunk }` / `{ done }` lines (same pattern as today’s IO API). |
+| **Orchestrator → IO injection** | `POST …/api/orchestrator/stream-events` | Body = same envelope as SSE `data:`. IO BFF forwards to all subscribers for `payload.taskId`. For production, protect this route (network ACL, mTLS, or shared secret). |
+| **WebSocket** | Optional later | Same JSON frames as SSE `data:` payloads; IO web client can swap transport behind a thin adapter without changing payload shapes. |
+| **Browser auth** | `X-Surface-Key` on **mutating** HTTP calls | `EventSource` cannot set custom headers today; session cookies or a **query token** on the SSE URL are acceptable follow-ups. |
+| **Retries** | Client reconnect with backoff | On SSE error, UI may fall back to **local mock heartbeats** for demo tasks until the stream recovers (IO web behavior). |
+
+**Reference implementation:** `io/api` (Hono) implements the SSE hub, chat stream, and `POST /api/orchestrator/stream-events`. Shared parsing: `parseOrchestratorStreamEvent` in `@cerberos/io-core`.
+
 ### 1.1 Status updates (semantic heartbeat)
 
 The IO component needs **heartbeat-like status updates** from the orchestrator for each task so the UI can show whether a task is being worked on, is awaiting user input, or is done, and when the next user input is expected.
@@ -189,6 +205,7 @@ Each log entry should include at least:
 
 | Interface | Direction | Purpose |
 |-----------|-----------|---------|
+| **Transport (push)** | Orchestrator → IO | Default: SSE per task (`GET /api/events/{taskId}`) with enveloped JSON (`status` / `credential_request`). Inject: `POST /api/orchestrator/stream-events`. |
 | **Status updates** | Orchestrator → IO | Semantic heartbeat per task: status, lastUpdate, expectedNextInputMinutes (scalar, minutes from now); 1–4 s per task, push or poll. |
 | **Chat (send)** | IO → Orchestrator | User message + optional history; taskId required. |
 | **Chat (stream)** | Orchestrator → IO | Streamed assistant reply (chunks); IO accumulates and displays. |

--- a/io/surfaces/web/src/App.tsx
+++ b/io/surfaces/web/src/App.tsx
@@ -1,5 +1,11 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
-import type { Task, ChatMessage, CredentialRequest, CredentialRequestStatus } from '@cerberos/io-core'
+import type {
+  Task,
+  ChatMessage,
+  CredentialRequest,
+  CredentialRequestStatus,
+  OrchestratorStreamEvent,
+} from '@cerberos/io-core'
 import TaskSidebar from './components/TaskSidebar'
 import ChatWindow from './components/ChatWindow'
 import CredentialModal from './components/CredentialModal'
@@ -8,7 +14,13 @@ import SettingsPanel, { defaultUISettings } from './components/SettingsPanel'
 import type { UISettings } from './components/SettingsPanel'
 import ActivityLog from './components/ActivityLog'
 import type { LogEntry } from './components/ActivityLog'
-import { streamOrchestratorReply, submitCredential } from './api/orchestrator'
+import {
+  streamOrchestratorReply,
+  submitCredential,
+  subscribeOrchestratorTaskStream,
+  orchestratorSseEnabled,
+  formatExpectedNextInput,
+} from './api/orchestrator'
 import { createWebSurface, type SurfaceAdapter } from './surface'
 import './App.css'
 
@@ -52,6 +64,16 @@ function timeLabel(): string {
 /** Random 2000–4000 ms in 100 ms increments (mock heartbeat interval). */
 function randomHeartbeatMs(): number {
   return Math.floor(Math.random() * 21) * 100 + 2000
+}
+
+/** When SSE is unavailable, keep the midterm demo credential flow for task 13. */
+const FALLBACK_TASK_13_CREDENTIAL: CredentialRequest = {
+  taskId: '13',
+  requestId: 'cred-13-dbpwd',
+  userId: '00000000-0000-0000-0000-000000000001',
+  keyName: 'prod_db_admin_password',
+  label: 'Production database admin password',
+  description: 'Required to execute the migration on the production cluster.',
 }
 
 const mockTasks: Task[] = [
@@ -211,23 +233,13 @@ function App() {
   const heartbeatIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const [taskHeartbeats, setTaskHeartbeats] = useState<Record<string, number>>({})
   const taskNextHeartbeatAtRef = useRef<Record<string, number>>({})
+  /** When false, semantic heartbeats come from Orchestrator SSE; when true, local mock timers (API down or env). */
+  const [useMockHeartbeat, setUseMockHeartbeat] = useState(() => !orchestratorSseEnabled())
 
-  // Credential state — completely separate from the chat pipeline
+  // Credential state — completely separate from the chat pipeline (populated via SSE / orchestrator push)
   const [credentialRequests, setCredentialRequests] = useState<
     Record<string, { request: CredentialRequest; status: CredentialRequestStatus }>
-  >({
-    '13': {
-      request: {
-        taskId: '13',
-        requestId: 'cred-13-dbpwd',
-        userId: '00000000-0000-0000-0000-000000000001',
-        keyName: 'prod_db_admin_password',
-        label: 'Production database admin password',
-        description: 'Required to execute the migration on the production cluster.',
-      },
-      status: 'pending',
-    },
-  })
+  >({})
   const [showCredentialModal, setShowCredentialModal] = useState(false)
   const [activeCredentialTaskId, setActiveCredentialTaskId] = useState<string | null>(null)
 
@@ -250,6 +262,75 @@ function App() {
     document.documentElement.setAttribute('data-font-scale', uiSettings.fontSizeScale)
     document.documentElement.setAttribute('data-high-contrast', uiSettings.highContrast ? 'true' : 'false')
   }, [uiSettings.fontSizeScale, uiSettings.highContrast])
+
+  // Orchestrator → IO push stream (SSE) for status + credential_request
+  useEffect(() => {
+    if (!orchestratorSseEnabled()) return
+
+    let cancelled = false
+
+    const onEvent = (ev: OrchestratorStreamEvent) => {
+      if (cancelled) return
+      if (ev.type === 'status') {
+        const p = ev.payload
+        setTasks(prev =>
+          prev.map(t =>
+            t.id === p.taskId
+              ? {
+                  ...t,
+                  status: p.status,
+                  lastUpdate: p.lastUpdate,
+                  expectedNextInput: formatExpectedNextInput(p.expectedNextInputMinutes),
+                }
+              : t,
+          ),
+        )
+        setTaskHeartbeats(prev => ({ ...prev, [p.taskId]: Date.now() }))
+      } else {
+        setCredentialRequests(prev => {
+          const ex = prev[ev.payload.taskId]
+          if (
+            ex?.status === 'submitted' &&
+            ex.request.requestId === ev.payload.requestId
+          ) {
+            return prev
+          }
+          return {
+            ...prev,
+            [ev.payload.taskId]: { request: ev.payload, status: 'pending' },
+          }
+        })
+      }
+    }
+
+    const unsub = subscribeOrchestratorTaskStream(selectedTaskId, {
+      onOpen: () => {
+        if (!cancelled) setUseMockHeartbeat(false)
+      },
+      onEvent,
+      onTransportError: () => {
+        if (!cancelled) setUseMockHeartbeat(true)
+      },
+    })
+
+    return () => {
+      cancelled = true
+      unsub()
+    }
+  }, [selectedTaskId])
+
+  // Offline / API-down: still show credential demo for task 13 (matches IO API demo push)
+  useEffect(() => {
+    if (!useMockHeartbeat) return
+    if (selectedTaskId !== '13') return
+    setCredentialRequests(prev => {
+      if (prev['13']) return prev
+      return {
+        ...prev,
+        '13': { request: FALLBACK_TASK_13_CREDENTIAL, status: 'pending' },
+      }
+    })
+  }, [useMockHeartbeat, selectedTaskId])
 
   // Refs to hold callbacks for SurfaceAdapter integration
   const tasksRef = useRef(tasks)
@@ -402,6 +483,14 @@ function App() {
       return
     }
 
+    if (!useMockHeartbeat) {
+      if (heartbeatIntervalRef.current) {
+        clearInterval(heartbeatIntervalRef.current)
+        heartbeatIntervalRef.current = null
+      }
+      return
+    }
+
     heartbeatIntervalRef.current = setInterval(() => {
       const workingTasks = tasks.filter(t => t.status === 'working')
       if (workingTasks.length > 0) {
@@ -420,7 +509,7 @@ function App() {
         clearInterval(heartbeatIntervalRef.current)
       }
     }
-  }, [uiSettings.showActivityLog, tasks, addLogEntry])
+  }, [uiSettings.showActivityLog, tasks, addLogEntry, useMockHeartbeat])
 
   const handleCreateTask = () => {
     const newTaskId = nextId()

--- a/io/surfaces/web/src/api/orchestrator.ts
+++ b/io/surfaces/web/src/api/orchestrator.ts
@@ -8,9 +8,75 @@
  * The Orchestrator never sees plaintext secrets.
  */
 
+import { parseOrchestratorStreamEvent, type OrchestratorStreamEvent } from '@cerberos/io-core'
+
 export interface OrchestratorMessage {
   role: 'user' | 'assistant'
   content: string
+}
+
+/** Base URL for IO API (no trailing slash). Empty = same origin (Vite proxy in dev). */
+export function getIoApiBase(): string {
+  const v = import.meta.env.VITE_IO_API_BASE as string | undefined
+  return v ? v.replace(/\/$/, '') : ''
+}
+
+export function buildApiUrl(path: string): string {
+  const base = getIoApiBase()
+  const p = path.startsWith('/') ? path : `/${path}`
+  return base ? `${base}${p}` : p
+}
+
+/** When false (`VITE_ORCHESTRATOR_SSE=0` or `false`), UI uses local mock heartbeats only. */
+export function orchestratorSseEnabled(): boolean {
+  const v = import.meta.env.VITE_ORCHESTRATOR_SSE as string | undefined
+  if (v === '0' || v === 'false') return false
+  return true
+}
+
+export function formatExpectedNextInput(minutes: number | null): string {
+  if (minutes === null) return 'Done'
+  if (minutes === 0) return 'Now'
+  return `~${minutes} min`
+}
+
+/**
+ * Subscribe to orchestrator→IO push events for one task (SSE).
+ * Returns unsubscribe. Uses enveloped events per io-interfaces.md §1.0.
+ */
+export function subscribeOrchestratorTaskStream(
+  taskId: string,
+  handlers: {
+    onEvent: (event: OrchestratorStreamEvent) => void
+    onOpen?: () => void
+    onTransportError?: () => void
+  },
+): () => void {
+  const url = buildApiUrl(`/api/events/${encodeURIComponent(taskId)}`)
+  const es = new EventSource(url)
+
+  es.onopen = () => {
+    handlers.onOpen?.()
+  }
+
+  es.onmessage = (e: MessageEvent<string>) => {
+    try {
+      const raw = JSON.parse(e.data) as unknown
+      const parsed = parseOrchestratorStreamEvent(raw)
+      if (parsed) handlers.onEvent(parsed)
+    } catch {
+      /* ignore bad frame */
+    }
+  }
+
+  es.onerror = () => {
+    handlers.onTransportError?.()
+    es.close()
+  }
+
+  return () => {
+    es.close()
+  }
 }
 
 export interface CredentialSubmitParams {
@@ -42,7 +108,7 @@ export async function submitCredential(
 ): Promise<CredentialSubmitResult> {
   try {
     // POST to IO API's credential endpoint, which proxies to Memory Vault
-    const res = await fetch('/api/credential', {
+    const res = await fetch(buildApiUrl('/api/credential'), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -74,7 +140,7 @@ export async function* streamOrchestratorReply(
   userContent: string,
   conversationHistory: OrchestratorMessage[],
 ): AsyncGenerator<string, void, unknown> {
-  const res = await fetch('/api/chat', {
+  const res = await fetch(buildApiUrl('/api/chat'), {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/io/surfaces/web/src/vite-env.d.ts
+++ b/io/surfaces/web/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_IO_API_BASE?: string
+  readonly VITE_ORCHESTRATOR_SSE?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
Fixes #81
Fixes #82
Fixes #83
Fixes #84

## Summary

- **§1.0 transport** in `io/io-interfaces.md`: SSE default, enveloped events, `POST /api/orchestrator/stream-events`, optional `VITE_IO_API_BASE` / `VITE_ORCHESTRATOR_SSE`.
- **io-core**: `OrchestratorStreamEvent`, `parseOrchestratorStreamEvent` (legacy bare `StatusUpdate` supported).
- **io-api**: SSE subscriber hub, status broadcast on chat lifecycle, orchestrator push endpoint, task-13 demo credential on stream connect.
- **Web**: `EventSource` per selected task, mock heartbeat fallback when SSE disabled or fails; offline fallback credential for task 13.

All changes under `io/`.
