### PR TITLE
fix(orchestrator): proxy /v1/databus/* to Memory API (fixes #117)

### DIFF
--- a/orchestrator/cmd/orchestrator/main.go
+++ b/orchestrator/cmd/orchestrator/main.go
@@ -22,10 +22,12 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
 	"github.com/mlim3/cerberOS/orchestrator/internal/config"
+	"github.com/mlim3/cerberOS/orchestrator/internal/databusproxy"
 	"github.com/mlim3/cerberOS/orchestrator/internal/dispatcher"
 	"github.com/mlim3/cerberOS/orchestrator/internal/executor"
 	"github.com/mlim3/cerberOS/orchestrator/internal/gateway"
@@ -57,9 +59,21 @@ func main() {
 	rt.health.StartMonitorLoop(cfg.HealthCheckIntervalSeconds, cfg.HealthCheckIntervalSeconds)
 	go func() {
 		addr := ":8080"
-		log.Printf("health endpoint listening on %s", addr)
-		if err := http.ListenAndServe(addr, http.HandlerFunc(rt.health.ServeHTTP)); err != nil {
-			log.Printf("health server stopped: %v", err)
+		mux := http.NewServeMux()
+		mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			rt.health.ServeHTTP(w, r)
+		})
+		if isHTTPMemoryEndpoint(cfg.MemoryEndpoint) {
+			mux.Handle("/v1/databus/", databusproxy.New(cfg.MemoryEndpoint))
+			log.Printf("databus proxy enabled: /v1/databus/* -> %s/*", strings.TrimSuffix(cfg.MemoryEndpoint, "/"))
+		}
+		log.Printf("HTTP listening on %s", addr)
+		if err := http.ListenAndServe(addr, mux); err != nil {
+			log.Printf("HTTP server stopped: %v", err)
 		}
 	}()
 
@@ -273,6 +287,11 @@ func boolToInt(v bool) int {
 		return 1
 	}
 	return 0
+}
+
+func isHTTPMemoryEndpoint(s string) bool {
+	s = strings.TrimSpace(s)
+	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
 }
 
 func demoConfig() *config.OrchestratorConfig {

--- a/orchestrator/internal/databusproxy/proxy.go
+++ b/orchestrator/internal/databusproxy/proxy.go
@@ -1,0 +1,41 @@
+// Package databusproxy implements HTTP proxy routes for aegis-databus when it
+// uses AEGIS_ORCHESTRATOR_URL: DataBus calls /v1/databus/* on the orchestrator,
+// which must forward to the Memory API under MEMORY_ENDPOINT (e.g. .../v1/memory/*).
+package databusproxy
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+)
+
+// New returns a handler that reverse-proxies /v1/databus/* to the Memory HTTP API.
+// memoryBaseURL is the full base of the Memory component REST API, for example
+// http://memory-api:8081/v1/memory (no trailing slash).
+func New(memoryBaseURL string) http.Handler {
+	memoryBaseURL = strings.TrimSuffix(strings.TrimSpace(memoryBaseURL), "/")
+	base, err := url.Parse(memoryBaseURL)
+	if err != nil || base.Scheme == "" || base.Host == "" {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "invalid MEMORY_ENDPOINT for databus proxy", http.StatusInternalServerError)
+		})
+	}
+
+	proxy := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			path := req.URL.Path
+			if strings.HasPrefix(path, "/v1/databus/") {
+				path = strings.TrimPrefix(path, "/v1/databus/")
+				if !strings.HasPrefix(path, "/") {
+					path = "/" + path
+				}
+			}
+			req.URL.Scheme = base.Scheme
+			req.URL.Host = base.Host
+			req.URL.Path = strings.TrimSuffix(base.Path, "/") + path
+			req.Host = base.Host
+		},
+	}
+	return proxy
+}

--- a/orchestrator/internal/databusproxy/proxy_test.go
+++ b/orchestrator/internal/databusproxy/proxy_test.go
@@ -1,0 +1,43 @@
+package databusproxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNew_forwardsToMemoryPath(t *testing.T) {
+	var gotPath string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer backend.Close()
+
+	h := New(backend.URL + "/v1/memory")
+	req := httptest.NewRequest(http.MethodGet, "/v1/databus/outbox/pending?limit=3", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if gotPath != "/v1/memory/outbox/pending" {
+		t.Fatalf("proxied path = %q, want /v1/memory/outbox/pending", gotPath)
+	}
+	body, _ := io.ReadAll(rec.Body)
+	if string(body) != "[]" {
+		t.Fatalf("body = %q", body)
+	}
+}
+
+func TestNew_invalidBaseURL(t *testing.T) {
+	h := New("not-a-url")
+	req := httptest.NewRequest(http.MethodGet, "/v1/databus/ping", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+}


### PR DESCRIPTION
Register a reverse proxy on the orchestrator HTTP server when MEMORY_ENDPOINT is an http(s) URL, matching aegis-databus OrchestratorStorageClient paths to the Memory API (outbox, audit, ping, processed).

Serve /health only on GET /health instead of all paths.

