### PR TITLE
docs: add comprehensive GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug Report
+about: Report a defect or unexpected behavior
+title: "fix: [component] describe issue"
+labels: bug
+assignees: ""
+---
+
+## Overview
+<!-- Describe what went wrong in 1-2 sentences. -->
+
+## Expected Behavior
+<!-- What should happen instead? -->
+
+## Actual Behavior
+<!-- What actually happens? Include error messages, stack traces, or logs. -->
+
+## Steps to Reproduce
+1.
+2.
+3.
+
+## Environment
+- **Component(s):** <!-- e.g., Agents, Orchestrator, Memory, Vault, etc. -->
+- **OS/Platform:** 
+- **Go Version (if applicable):** 
+- **Docker/Container Environment (if applicable):** 
+
+## Logs or Error Messages
+<!-- Paste relevant logs, error output, or stack traces here. Use code blocks. -->
+```
+```
+
+## Additional Context
+<!-- Anything else that might help (screenshots, related issues, env vars)? -->
+
+## Severity
+- [ ] P0 — Blocking (system broken, data loss, security issue)
+- [ ] P1 — High (core functionality broken)
+- [ ] P2 — Medium (feature degraded)
+- [ ] P3+ — Low (nice to have, cosmetic)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Agents Component Docs
+    url: https://github.com/mlim3/cerberOS/tree/main/agents-component/docs
+    about: Read the Agents Component architecture and specifications
+  - name: Vault Docs
+    url: https://github.com/mlim3/cerberOS/tree/main/vault
+    about: Credential Vault service documentation
+  - name: Architecture & Design
+    url: https://github.com/mlim3/cerberOS/tree/main/design_docs
+    about: Engineering design docs and decision records

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,37 @@
+---
+name: Documentation
+about: Improve or add documentation
+title: "docs: [section] describe update"
+labels: documentation
+assignees: ""
+---
+
+## Overview
+<!-- What documentation is missing or unclear? -->
+
+## Section(s) Affected
+<!-- Which files or areas need updating? E.g., README.md, CLAUDE.md, architecture docs, etc. -->
+
+## Current State
+<!-- What exists today (if anything)? -->
+
+## Proposed Changes
+<!-- What should be added/clarified? Include outline or draft if helpful. -->
+
+## Audience
+<!-- Who is this documentation for? (developers, operators, agents, etc.) -->
+
+## Acceptance Criteria
+- [ ] Documentation is clear and complete
+- [ ] Examples are working and tested
+- [ ] Links to related docs are included
+- [ ] Documentation follows project style
+
+## Related Issues
+<!-- Link to any issues this documents. -->
+
+## Priority
+- [ ] P0 — Blocks other work
+- [ ] P1 — High priority
+- [ ] P2 — Medium priority
+- [ ] P3+ — Nice to have

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,45 @@
+---
+name: Feature Request
+about: Propose a new capability or enhancement
+title: "feat: [scope] describe capability"
+labels: enhancement
+assignees: ""
+---
+
+## Overview
+<!-- Describe the feature in 1-2 sentences. Why is it needed? -->
+
+## Problem It Solves
+<!-- What gap does this fill? Who benefits? -->
+
+## Proposed Solution
+<!-- How should it work? Include any design details. -->
+
+## Acceptance Criteria
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## Affected Components
+<!-- Which parts of cerberOS does this touch? -->
+- [ ] Agents Component
+- [ ] Orchestrator
+- [ ] Memory Component
+- [ ] Credential Vault (OpenBao)
+- [ ] Communications Component (NATS)
+- [ ] Other: ___
+
+## Performance / Security Notes
+<!-- Any non-functional requirements, performance targets, or security implications? -->
+
+## Related Issues
+<!-- Links to related issues, specs, or ADRs. -->
+
+## Priority
+- [ ] P0 — Critical path
+- [ ] P1 — High priority
+- [ ] P2 — Medium priority
+- [ ] P3+ — Nice to have
+
+## Additional Context
+<!-- Mockups, references, or other details. -->

--- a/.github/ISSUE_TEMPLATE/milestone.md
+++ b/.github/ISSUE_TEMPLATE/milestone.md
@@ -1,0 +1,54 @@
+---
+name: Milestone
+about: Track multi-step initiative or epic
+title: "Milestone: [component] describe goal"
+labels: milestone
+assignees: ""
+---
+
+## Overview
+<!-- High-level description of this initiative. What's the business goal? -->
+
+## Scope
+<!-- What components or subsystems does this span? -->
+
+## Sub-Tasks / Work Breakdown
+<!-- List major sub-issues or phases. Use checkboxes for progress tracking. -->
+- [ ] Sub-task 1 — description
+- [ ] Sub-task 2 — description
+- [ ] Sub-task 3 — description
+
+## Success Criteria
+<!-- How do we know this milestone is complete? -->
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## Timeline / Key Dates
+<!-- Expected milestones, deadlines, or phases. -->
+- **Phase 1:** 
+- **Phase 2:** 
+- **Target Completion:** 
+
+## Affected Components
+- [ ] Agents Component
+- [ ] Orchestrator
+- [ ] Memory Component
+- [ ] Credential Vault (OpenBao)
+- [ ] Communications Component (NATS)
+- [ ] Other: ___
+
+## Dependencies
+<!-- What must complete before this? Links to blocking issues. -->
+
+## Related Documentation
+<!-- Links to EDD, PRD, ADR, or design docs. -->
+
+## Priority
+- [ ] P0 — Critical path
+- [ ] P1 — High priority
+- [ ] P2 — Medium priority
+- [ ] P3+ — Nice to have
+
+## Notes
+<!-- Additional context, risks, or considerations. -->


### PR DESCRIPTION
## Overview
Add standardized GitHub issue templates to guide contributors and agents when creating issues. Templates are tailored to the cerberOS project structure with components (Agents, Orchestrator, Memory, Vault, Communications) and priority levels (P0-P3+).

## Changes

### New files
- `.github/ISSUE_TEMPLATE/bug_report.md` — Structured bug report template with environment and reproduction steps
- `.github/ISSUE_TEMPLATE/feature_request.md` — Feature request template with acceptance criteria and component selection
- `.github/ISSUE_TEMPLATE/documentation.md` — Documentation improvement template with section targeting
- `.github/ISSUE_TEMPLATE/milestone.md` — Multi-step initiative and epic tracking template
- `.github/ISSUE_TEMPLATE/config.yml` — Template configuration with helpful resource links

## Testing
1. Navigate to **Issues** → **New Issue** on GitHub
2. Verify all four templates appear as options
3. Click each template and verify:
   - Form sections render correctly
   - Checkboxes for priority and components work
   - Placeholder text is clear and helpful
4. Test creating a sample issue using each template
5. Verify the form helps structure the issue properly

## Notes
Templates follow project conventions:
- Priority labels (P0, P1, P2, P3+) for severity assessment
- Component checkboxes covering all major cerberOS subsystems
- Acceptance criteria and success metrics for clarity
- Reference to design docs and related documentation
- Similar structure to PR templates (see github-cli-workflow reference)

Fixes #131

Made with [Cursor](https://cursor.com)