### PR TITLE
fix(bootstrap): deterministic DB state - wipe volumes by default, --keep-volumes opt-out

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -170,6 +170,20 @@ cmd_up() {
     psql -U "${POSTGRES_USER:-user}" -d "${POSTGRES_DB:-memory_db}" \
     -c "CREATE DATABASE openbao OWNER \"${POSTGRES_USER:-user}\""
 
+  # Re-apply the memory_db schema/seed on every bootstrap. The docker-entrypoint
+  # init scripts only run when the Postgres data dir is empty, so teammates with
+  # pre-existing volumes silently miss any new tables, indexes, or seed rows
+  # added to init-db.sql. Running it here (the file is idempotent —
+  # CREATE ... IF NOT EXISTS, INSERT ... ON CONFLICT DO NOTHING) guarantees
+  # every machine converges on the same schema + seed state after bootstrap,
+  # without destroying user-generated rows.
+  log "Re-applying memory_db schema/seed (idempotent)..."
+  docker compose exec -T memory-db \
+    psql -U "${POSTGRES_USER:-user}" -d "${POSTGRES_DB:-memory_db}" \
+    -v ON_ERROR_STOP=1 \
+    -f /docker-entrypoint-initdb.d/01-init-db.sql >/dev/null \
+    || die "failed to re-apply memory/scripts/init-db.sql"
+
   log "Starting remaining Docker services..."
   docker compose up --build --detach
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -209,12 +209,23 @@ cmd_up() {
   # so this is a no-op on a genuinely up-to-date DB and cannot clobber
   # user-generated rows. Skipped on the default wipe path because
   # docker-entrypoint will have just run it fresh on the empty volume.
+  #
+  # Stream the file from the host via stdin rather than passing a container
+  # path to `psql -f`. Git Bash / MSYS on Windows rewrites any absolute
+  # argument starting with `/` into a Windows path (e.g.
+  # `/docker-entrypoint-initdb.d/01-init-db.sql` becomes
+  # `C:/Program Files/Git/docker-entrypoint-initdb.d/...`) which breaks `exec`
+  # even though the path was meant to be interpreted inside the container.
+  # stdin avoids that entirely and also uses the checked-out script directly
+  # instead of relying on the docker-entrypoint bind mount being in sync.
   if [[ "$keep_volumes" == true ]]; then
     log "Re-applying memory_db schema/seed (idempotent) for --keep-volumes..."
+    [[ -f "$ROOT/memory/scripts/init-db.sql" ]] \
+      || die "memory/scripts/init-db.sql not found at $ROOT"
     docker compose exec -T memory-db \
       psql -U "${POSTGRES_USER:-user}" -d "${POSTGRES_DB:-memory_db}" \
       -v ON_ERROR_STOP=1 \
-      -f /docker-entrypoint-initdb.d/01-init-db.sql >/dev/null \
+      < "$ROOT/memory/scripts/init-db.sql" >/dev/null \
       || die "failed to re-apply memory/scripts/init-db.sql"
   fi
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,10 +2,16 @@
 # cerberOS bootstrap — bring the full stack up or tear it down.
 #
 # Usage:
-#   ./bootstrap.sh                # build, start, init + unseal OpenBao
-#   ./bootstrap.sh down           # stop stack, clean up OpenBao state
+#   ./bootstrap.sh                       # wipe volumes, build, start, init + unseal OpenBao
+#   ./bootstrap.sh --keep-volumes        # build, start, init + unseal OpenBao without wiping volumes
+#   ./bootstrap.sh down                  # stop stack, clean up OpenBao state
 #   ./bootstrap.sh down --keep-db        # stop but keep openbao database
 #   ./bootstrap.sh down --delete-volumes # stop and remove Docker volumes
+#
+# By default `up` wipes the Docker volumes before bringing the stack up, so every
+# teammate ends a bootstrap run on the same schema and seed state regardless of
+# prior volume history. Use --keep-volumes when you want to preserve local chat,
+# vault secrets, or other data across a bootstrap.
 
 set -euo pipefail
 
@@ -100,6 +106,14 @@ cmd_down() {
 # UP
 # =============================================================================
 cmd_up() {
+  local keep_volumes=false
+  for arg in "$@"; do
+    case "$arg" in
+      --keep-volumes) keep_volumes=true ;;
+      *) die "unknown option: $arg" ;;
+    esac
+  done
+
   # --- Prerequisites ---
   require_cmd docker
   docker info >/dev/null 2>&1 || die "Docker is not running or not accessible"
@@ -113,6 +127,24 @@ cmd_up() {
     die "use Docker Compose v2 (docker compose), not docker-compose"
   else
     die "docker compose (v2) is required"
+  fi
+
+  # --- Wipe volumes (default) ---
+  # Bootstrap is meant to produce a known, identical starting state on every
+  # teammate's machine. `docker-entrypoint-initdb.d` scripts only run when the
+  # Postgres data dir is empty, so preserving volumes silently ships stale
+  # schema and seed rows to whoever bootstraps against an older volume.
+  # Wiping by default eliminates that drift; --keep-volumes is the explicit
+  # opt-out when a dev wants to preserve local data across a bootstrap.
+  if [[ "$keep_volumes" == false ]]; then
+    log "Wiping Docker volumes (opt out with --keep-volumes)..."
+    docker compose down -v --remove-orphans 2>/dev/null || true
+    rm -f "$ROOT/vault/.openbao-init.json"
+    if [[ -f "$ROOT/.env" ]] && grep -q "^BAO_TOKEN=" "$ROOT/.env" 2>/dev/null; then
+      upsert_env_var "$ROOT/.env" "BAO_TOKEN" ""
+    fi
+  else
+    log "Keeping existing Docker volumes (--keep-volumes)."
   fi
 
   # --- .env ---
@@ -170,19 +202,21 @@ cmd_up() {
     psql -U "${POSTGRES_USER:-user}" -d "${POSTGRES_DB:-memory_db}" \
     -c "CREATE DATABASE openbao OWNER \"${POSTGRES_USER:-user}\""
 
-  # Re-apply the memory_db schema/seed on every bootstrap. The docker-entrypoint
-  # init scripts only run when the Postgres data dir is empty, so teammates with
-  # pre-existing volumes silently miss any new tables, indexes, or seed rows
-  # added to init-db.sql. Running it here (the file is idempotent —
-  # CREATE ... IF NOT EXISTS, INSERT ... ON CONFLICT DO NOTHING) guarantees
-  # every machine converges on the same schema + seed state after bootstrap,
-  # without destroying user-generated rows.
-  log "Re-applying memory_db schema/seed (idempotent)..."
-  docker compose exec -T memory-db \
-    psql -U "${POSTGRES_USER:-user}" -d "${POSTGRES_DB:-memory_db}" \
-    -v ON_ERROR_STOP=1 \
-    -f /docker-entrypoint-initdb.d/01-init-db.sql >/dev/null \
-    || die "failed to re-apply memory/scripts/init-db.sql"
+  # On --keep-volumes runs, Postgres skips docker-entrypoint-initdb.d because
+  # the data dir already exists, so new tables/indexes/seed rows added to
+  # init-db.sql would not land. Re-apply the script explicitly — it is
+  # idempotent (CREATE ... IF NOT EXISTS, INSERT ... ON CONFLICT DO NOTHING)
+  # so this is a no-op on a genuinely up-to-date DB and cannot clobber
+  # user-generated rows. Skipped on the default wipe path because
+  # docker-entrypoint will have just run it fresh on the empty volume.
+  if [[ "$keep_volumes" == true ]]; then
+    log "Re-applying memory_db schema/seed (idempotent) for --keep-volumes..."
+    docker compose exec -T memory-db \
+      psql -U "${POSTGRES_USER:-user}" -d "${POSTGRES_DB:-memory_db}" \
+      -v ON_ERROR_STOP=1 \
+      -f /docker-entrypoint-initdb.d/01-init-db.sql >/dev/null \
+      || die "failed to re-apply memory/scripts/init-db.sql"
+  fi
 
   log "Starting remaining Docker services..."
   docker compose up --build --detach
@@ -320,5 +354,6 @@ cmd_up() {
 case "${1:-up}" in
   up)      [[ $# -gt 0 ]] && shift; cmd_up "$@" ;;
   down)    [[ $# -gt 0 ]] && shift; cmd_down "$@" ;;
+  -*)      cmd_up "$@" ;;
   *)       die "usage: $0 [up|down] [options]" ;;
 esac

--- a/memory/scripts/init-db.sql
+++ b/memory/scripts/init-db.sql
@@ -11,7 +11,7 @@ CREATE SCHEMA IF NOT EXISTS service_log_schema;
 -- ==========================================
 -- identity_schema
 -- ==========================================
-CREATE TABLE identity_schema.users (
+CREATE TABLE IF NOT EXISTS identity_schema.users (
     id UUID PRIMARY KEY,
     email VARCHAR(255) UNIQUE NOT NULL,
     created_at TIMESTAMPTZ DEFAULT NOW()
@@ -20,7 +20,7 @@ CREATE TABLE identity_schema.users (
 -- ==========================================
 -- chat_schema
 -- ==========================================
-CREATE TABLE chat_schema.messages (
+CREATE TABLE IF NOT EXISTS chat_schema.messages (
     id UUID PRIMARY KEY,
     session_id UUID NOT NULL,
     user_id UUID NOT NULL,
@@ -31,16 +31,16 @@ CREATE TABLE chat_schema.messages (
     created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
-CREATE INDEX idx_messages_session_id ON chat_schema.messages(session_id);
-CREATE INDEX idx_messages_user_id ON chat_schema.messages(user_id);
-CREATE UNIQUE INDEX idx_messages_session_idempotency
+CREATE INDEX IF NOT EXISTS idx_messages_session_id ON chat_schema.messages(session_id);
+CREATE INDEX IF NOT EXISTS idx_messages_user_id ON chat_schema.messages(user_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_session_idempotency
     ON chat_schema.messages(session_id, idempotency_key)
     WHERE idempotency_key IS NOT NULL;
 
 -- ==========================================
 -- personal_info_schema
 -- ==========================================
-CREATE TABLE personal_info_schema.personal_info_chunks (
+CREATE TABLE IF NOT EXISTS personal_info_schema.personal_info_chunks (
     id UUID PRIMARY KEY,
     user_id UUID NOT NULL,
     raw_text TEXT NOT NULL,
@@ -49,10 +49,10 @@ CREATE TABLE personal_info_schema.personal_info_chunks (
     created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
-CREATE INDEX idx_personal_info_chunks_user_id ON personal_info_schema.personal_info_chunks(user_id);
-CREATE INDEX idx_personal_info_chunks_embedding ON personal_info_schema.personal_info_chunks USING hnsw (embedding vector_cosine_ops);
+CREATE INDEX IF NOT EXISTS idx_personal_info_chunks_user_id ON personal_info_schema.personal_info_chunks(user_id);
+CREATE INDEX IF NOT EXISTS idx_personal_info_chunks_embedding ON personal_info_schema.personal_info_chunks USING hnsw (embedding vector_cosine_ops);
 
-CREATE TABLE personal_info_schema.user_facts (
+CREATE TABLE IF NOT EXISTS personal_info_schema.user_facts (
     id UUID PRIMARY KEY,
     user_id UUID NOT NULL,
     category VARCHAR(50),
@@ -63,10 +63,10 @@ CREATE TABLE personal_info_schema.user_facts (
     updated_at TIMESTAMPTZ DEFAULT NOW()
 );
 
-CREATE INDEX idx_user_facts_user_id ON personal_info_schema.user_facts(user_id);
-CREATE INDEX idx_user_facts_category ON personal_info_schema.user_facts(category);
+CREATE INDEX IF NOT EXISTS idx_user_facts_user_id ON personal_info_schema.user_facts(user_id);
+CREATE INDEX IF NOT EXISTS idx_user_facts_category ON personal_info_schema.user_facts(category);
 
-CREATE TABLE personal_info_schema.source_references (
+CREATE TABLE IF NOT EXISTS personal_info_schema.source_references (
     id UUID PRIMARY KEY,
     user_id UUID NOT NULL,
     target_id UUID NOT NULL,
@@ -75,14 +75,14 @@ CREATE TABLE personal_info_schema.source_references (
     source_type VARCHAR(50) NOT NULL
 );
 
-CREATE INDEX idx_source_references_user_id ON personal_info_schema.source_references(user_id);
-CREATE INDEX idx_source_references_target_id ON personal_info_schema.source_references(target_id);
-CREATE INDEX idx_source_references_source_id ON personal_info_schema.source_references(source_id);
+CREATE INDEX IF NOT EXISTS idx_source_references_user_id ON personal_info_schema.source_references(user_id);
+CREATE INDEX IF NOT EXISTS idx_source_references_target_id ON personal_info_schema.source_references(target_id);
+CREATE INDEX IF NOT EXISTS idx_source_references_source_id ON personal_info_schema.source_references(source_id);
 
 -- ==========================================
 -- agent_logs_schema
 -- ==========================================
-CREATE TABLE agent_logs_schema.task_executions (
+CREATE TABLE IF NOT EXISTS agent_logs_schema.task_executions (
     id UUID PRIMARY KEY,
     task_id UUID NOT NULL,
     agent_id VARCHAR(100) NOT NULL,
@@ -93,13 +93,13 @@ CREATE TABLE agent_logs_schema.task_executions (
     created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
-CREATE INDEX idx_task_executions_task_id ON agent_logs_schema.task_executions(task_id);
-CREATE INDEX idx_task_executions_agent_id ON agent_logs_schema.task_executions(agent_id);
+CREATE INDEX IF NOT EXISTS idx_task_executions_task_id ON agent_logs_schema.task_executions(task_id);
+CREATE INDEX IF NOT EXISTS idx_task_executions_agent_id ON agent_logs_schema.task_executions(agent_id);
 
 -- ==========================================
 -- service_log_schema
 -- ==========================================
-CREATE TABLE service_log_schema.system_events (
+CREATE TABLE IF NOT EXISTS service_log_schema.system_events (
     id UUID PRIMARY KEY,
     trace_id UUID,
     service_name VARCHAR(100),
@@ -109,16 +109,16 @@ CREATE TABLE service_log_schema.system_events (
     created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
-CREATE INDEX idx_system_events_trace_id ON service_log_schema.system_events(trace_id);
-CREATE INDEX idx_system_events_service_name ON service_log_schema.system_events(service_name);
-CREATE INDEX idx_system_events_severity ON service_log_schema.system_events(severity);
+CREATE INDEX IF NOT EXISTS idx_system_events_trace_id ON service_log_schema.system_events(trace_id);
+CREATE INDEX IF NOT EXISTS idx_system_events_service_name ON service_log_schema.system_events(service_name);
+CREATE INDEX IF NOT EXISTS idx_system_events_severity ON service_log_schema.system_events(severity);
 
 -- ==========================================
 -- vault_schema
 -- ==========================================
 CREATE SCHEMA IF NOT EXISTS vault_schema;
 
-CREATE TABLE vault_schema.secrets (
+CREATE TABLE IF NOT EXISTS vault_schema.secrets (
     id UUID PRIMARY KEY,
     user_id UUID NOT NULL,
     key_name VARCHAR(255) NOT NULL,
@@ -128,4 +128,4 @@ CREATE TABLE vault_schema.secrets (
     UNIQUE(user_id, key_name)
 );
 
-CREATE INDEX idx_secrets_user_id ON vault_schema.secrets(user_id);
+CREATE INDEX IF NOT EXISTS idx_secrets_user_id ON vault_schema.secrets(user_id);


### PR DESCRIPTION
## Summary

Makes `bootstrap.sh` produce a deterministic starting state on every teammate's machine, so end-to-end PR testing is reproducible regardless of a dev's local volume history.

## Problem

`bootstrap.sh up` relied on `docker-entrypoint-initdb.d` to apply `memory/scripts/init-db.sql`, but that entrypoint only runs when the Postgres data dir is **empty**. Anyone who had already bootstrapped once kept a populated `postgres-data` volume and silently missed any new tables, indexes, or seed rows added by later PRs.

Concrete symptom that surfaced this: on `memory-v1`, the UI returned `404 user not found` for all chat/task APIs because teammates with stale volumes never picked up the `identity_schema.users` default seed. E2E testing of the PR was non-deterministic across machines.

## Fix

Two complementary changes:

### 1. `bootstrap.sh up` wipes volumes by default

```bash
./bootstrap.sh                    # wipe volumes, bring stack up fresh (default)
./bootstrap.sh up                 # same as above
./bootstrap.sh --keep-volumes     # opt-out: preserve volumes across bootstrap
./bootstrap.sh up --keep-volumes  # same as above
./bootstrap.sh down               # unchanged
```

Wipe path clears Docker volumes (`docker compose down -v --remove-orphans`), removes `vault/.openbao-init.json`, and clears `BAO_TOKEN` from `.env` so OpenBao re-initializes cleanly. `--keep-volumes` skips the wipe and preserves local chat/vault/etc.

Dispatcher also accepts `./bootstrap.sh <flag>` as implicit `up <flag>` so `./bootstrap.sh --keep-volumes` works without the explicit subcommand.

### 2. `memory/scripts/init-db.sql` is fully idempotent

Every `CREATE TABLE` and `CREATE INDEX` now uses `IF NOT EXISTS`; the default user seed already used `ON CONFLICT DO NOTHING`. On `--keep-volumes`, `bootstrap.sh` explicitly re-applies the script inside `memory-db` so new tables/indexes/seed rows land on pre-existing volumes without clobbering user-generated rows. On the default wipe path, the re-apply step is skipped because `docker-entrypoint` will have just run the same script on the freshly-wiped volume.

## Behavior change callout

**`./bootstrap.sh` now destroys local Docker volumes by default.** Devs who want to preserve local chat, vault secrets, or other data across a bootstrap must use `--keep-volumes`. The usage comment at the top of `bootstrap.sh` documents this; worth announcing in the team channel when this merges.

## Tests performed

- [x] `./bootstrap.sh` on a machine with stale `postgres-data` and `nats1-data` volumes → volumes recreated, OpenBao re-initialized (fresh root token + `BAO_TOKEN`), `init-db.sql` applied via docker-entrypoint, smoke test passes, fresh empty DB.
- [x] `./bootstrap.sh --keep-volumes` after dropping a marker row into `identity_schema.users` → volumes preserved, marker row survives, re-apply step logs and completes without error, smoke test passes.
- [x] `./bootstrap.sh --nope` → fails fast with `unknown option: --nope`.
- [x] `./bootstrap.sh foo` → fails with usage message (catch-all still guards non-flag garbage).

## Files

- `bootstrap.sh` — dispatcher accepts implicit `up`, `cmd_up` parses `--keep-volumes`, default wipe block added, conditional `init-db.sql` re-apply for `--keep-volumes`.
- `memory/scripts/init-db.sql` — `IF NOT EXISTS` on every `CREATE TABLE` / `CREATE INDEX` / `CREATE UNIQUE INDEX`.
