### PR TITLE
M4 logs standardization

### DIFF
--- a/aegis-databus/cmd/databus/main.go
+++ b/aegis-databus/cmd/databus/main.go
@@ -70,7 +70,7 @@ func main() {
 	shutdownTel, errInit := telemetry.Init(ctx)
 	if errInit != nil {
 		slog.New(slog.NewJSONHandler(os.Stdout, nil)).
-			With("service", "databus", "component", "server").
+			With("component", "databus", "module", "server").
 			Error("telemetry init failed", "error", errInit)
 		os.Exit(1)
 	}
@@ -81,8 +81,8 @@ func main() {
 	}()
 
 	baseLogger := slog.New(slog.NewJSONHandler(os.Stdout, nil)).
-		With("service", "databus")
-	logger := baseLogger.With("component", "server")
+		With("component", "databus")
+	logger := baseLogger.With("module", "server")
 	if telemetry.Enabled() {
 		logger.Info("OpenTelemetry OTLP export enabled")
 	}
@@ -236,7 +236,7 @@ func main() {
 	relay := &relay.OutboxRelay{
 		JS:           js,
 		MemoryClient: mem,
-		Logger:       baseLogger.With("component", "outbox-relay"),
+		Logger:       baseLogger.With("module", "outbox-relay"),
 	}
 	go relay.Start(ctx)
 
@@ -246,13 +246,13 @@ func main() {
 		checker = c
 	}
 	if os.Getenv("AEGIS_DLQ_REPLAY_ENABLED") == "1" {
-		rh := &dlq.ReplayHandler{JS: js, Checker: checker, Logger: baseLogger.With("component", "dlq-replay"), Component: "aegis-databus"}
+		rh := &dlq.ReplayHandler{JS: js, Checker: checker, Logger: baseLogger.With("module", "dlq-replay"), Component: "aegis-databus"}
 		go rh.Start(ctx)
 		logger.Info("DLQ replay handler started")
 	}
 
 	// Health heartbeat (legacy subject aegis.health.databus).
-	hb := health.NewHeartbeat(nc, baseLogger.With("component", "health-heartbeat"))
+	hb := health.NewHeartbeat(nc, baseLogger.With("module", "health-heartbeat"))
 	go hb.Start(ctx)
 
 	// Standardized service heartbeat (aegis.heartbeat.service.databus).
@@ -262,7 +262,7 @@ func main() {
 	go serviceHB.Start(ctx)
 
 	// JetStream gauges for Grafana (stream messages, bytes, pending)
-	go jetstreammetrics.Start(ctx, nc, jetstreammetrics.DefaultPollInterval, baseLogger.With("component", "jetstream-metrics"))
+	go jetstreammetrics.Start(ctx, nc, jetstreammetrics.DefaultPollInterval, baseLogger.With("module", "jetstream-metrics"))
 
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)

--- a/aegis-databus/cmd/databus/main.go
+++ b/aegis-databus/cmd/databus/main.go
@@ -56,10 +56,10 @@ func seedAuditDemo(ctx context.Context, m *memory.MockMemoryClient) {
 }
 
 const (
-	defaultNatsURL      = "nats://127.0.0.1:4222"
-	defaultNatsHTTPURL  = "http://127.0.0.1:8222"
-	metricsAddr         = ":9091"
-	memoryPingInterval  = 15 * time.Second
+	defaultNatsURL     = "nats://127.0.0.1:4222"
+	defaultNatsHTTPURL = "http://127.0.0.1:8222"
+	metricsAddr        = ":9091"
+	memoryPingInterval = 15 * time.Second
 )
 
 func main() {
@@ -80,13 +80,9 @@ func main() {
 		_ = shutdownTel(sctx)
 	}()
 
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil)).
-		With("service", "databus", "component", "server")
-	// Bridge for internal packages that still accept *log.Logger.
-	legacyLog := slog.NewLogLogger(
-		logger.Handler(),
-		slog.LevelInfo,
-	)
+	baseLogger := slog.New(slog.NewJSONHandler(os.Stdout, nil)).
+		With("service", "databus")
+	logger := baseLogger.With("component", "server")
 	if telemetry.Enabled() {
 		logger.Info("OpenTelemetry OTLP export enabled")
 	}
@@ -240,7 +236,7 @@ func main() {
 	relay := &relay.OutboxRelay{
 		JS:           js,
 		MemoryClient: mem,
-		Logger:       legacyLog,
+		Logger:       baseLogger.With("component", "outbox-relay"),
 	}
 	go relay.Start(ctx)
 
@@ -250,13 +246,13 @@ func main() {
 		checker = c
 	}
 	if os.Getenv("AEGIS_DLQ_REPLAY_ENABLED") == "1" {
-		rh := &dlq.ReplayHandler{JS: js, Checker: checker, Logger: legacyLog, Component: "aegis-databus"}
+		rh := &dlq.ReplayHandler{JS: js, Checker: checker, Logger: baseLogger.With("component", "dlq-replay"), Component: "aegis-databus"}
 		go rh.Start(ctx)
 		logger.Info("DLQ replay handler started")
 	}
 
 	// Health heartbeat (legacy subject aegis.health.databus).
-	hb := health.NewHeartbeat(nc, legacyLog)
+	hb := health.NewHeartbeat(nc, baseLogger.With("component", "health-heartbeat"))
 	go hb.Start(ctx)
 
 	// Standardized service heartbeat (aegis.heartbeat.service.databus).
@@ -266,7 +262,7 @@ func main() {
 	go serviceHB.Start(ctx)
 
 	// JetStream gauges for Grafana (stream messages, bytes, pending)
-	go jetstreammetrics.Start(ctx, nc, jetstreammetrics.DefaultPollInterval, legacyLog)
+	go jetstreammetrics.Start(ctx, nc, jetstreammetrics.DefaultPollInterval, baseLogger.With("component", "jetstream-metrics"))
 
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)

--- a/aegis-databus/cmd/demo/components.go
+++ b/aegis-databus/cmd/demo/components.go
@@ -4,7 +4,7 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"log"
+	"log/slog"
 	"sync/atomic"
 	"time"
 
@@ -16,14 +16,15 @@ import (
 
 // runIO simulates UI Layer: publishes user actions, subscribes to task updates.
 // comp is the ACL component id (e.g. io, orchestrator) per EDD §9.2.
-func runIO(ctx context.Context, nc *nats.Conn, js nats.JetStreamContext, logger *log.Logger, comp string) {
+func runIO(ctx context.Context, nc *nats.Conn, js nats.JetStreamContext, logger *slog.Logger, comp string) {
 	// Subscribe to task updates (FR-DB-001, FR-DB-005 wildcard) — SubscribeWithACL enforces SR-DB-006
 	if _, err := bus.SubscribeWithACL(js, comp, bus.SubjectTasks, func(m *nats.Msg) {
 		corr := extractCorr(m.Data)
-		logger.Printf("[I/O] received subject=%s size=%d correlation=%s", m.Subject, len(m.Data), corr)
+		taskID := extractTaskID(m.Data)
+		logger.Info("message received", "task_id", taskID, "subject", m.Subject, "size_bytes", len(m.Data), "request_id", corr)
 		m.Ack()
 	}, nats.Durable("io-tasks"), nats.ManualAck()); err != nil {
-		logger.Printf("[I/O] subscribe failed: %v", err)
+		logger.Error("subscribe failed", "subject", bus.SubjectTasks, "error", err)
 		return
 	}
 	time.Sleep(100 * time.Millisecond)
@@ -39,26 +40,27 @@ func runIO(ctx context.Context, nc *nats.Conn, js nats.JetStreamContext, logger 
 				"taskId": envelope.NewID(), "userId": "demo-user", "goal": "research task",
 			})
 			if err := envelope.Validate(ev.MustMarshal()); err != nil {
-				logger.Printf("[I/O] validation failed: %v", err)
+				logger.Error("validation failed", "task_id", taskIDFromEvent(ev), "error", err)
 				continue
 			}
 			if _, err := bus.PublishWithACL(js, comp, bus.SubjectUIAction, ev.MustMarshal()); err != nil {
-				logger.Printf("[I/O] publish failed: %v", err)
+				logger.Error("publish failed", "task_id", taskIDFromEvent(ev), "subject", bus.SubjectUIAction, "error", err)
 				continue
 			}
-			logger.Printf("[I/O] published aegis.ui.action correlation=%s", ev.CorrelationID)
+			logger.Info("message published", "task_id", taskIDFromEvent(ev), "subject", bus.SubjectUIAction, "request_id", ev.CorrelationID)
 		}
 	}
 }
 
 // runOrchestrator simulates Task Router + Task Planner + Agent Manager.
-func runOrchestrator(ctx context.Context, nc *nats.Conn, js nats.JetStreamContext, logger *log.Logger, comp string) {
+func runOrchestrator(ctx context.Context, nc *nats.Conn, js nats.JetStreamContext, logger *slog.Logger, comp string) {
 	var planCorr string
 
 	// Subscribe to UI actions
 	bus.SubscribeWithACL(js, comp, bus.SubjectUIAction, func(m *nats.Msg) {
 		corr := extractCorr(m.Data)
-		logger.Printf("[Orchestrator] received ui.action correlation=%s", corr)
+		taskID := extractTaskID(m.Data)
+		logger.Info("ui action received", "task_id", taskID, "request_id", corr)
 		m.Ack()
 		planCorr = corr
 
@@ -68,9 +70,9 @@ func runOrchestrator(ctx context.Context, nc *nats.Conn, js nats.JetStreamContex
 		reply, err := bus.Request(reqCtx, nc, bus.SubjectPersonalization, reqPayload, 5*time.Second)
 		cancel()
 		if err != nil {
-			logger.Printf("[Orchestrator] personalization request failed: %v", err)
+			logger.Error("personalization request failed", "task_id", taskID, "error", err)
 		} else {
-			logger.Printf("[Orchestrator] FR-DB-002 request-reply: personalization=%s", string(reply))
+			logger.Info("personalization request completed", "task_id", taskID, "reply_bytes", len(reply))
 		}
 		_ = reply
 
@@ -80,7 +82,7 @@ func runOrchestrator(ctx context.Context, nc *nats.Conn, js nats.JetStreamContex
 		})
 		ev.SetCorrelationID(corr)
 		bus.PublishWithACL(js, comp, bus.SubjectTasksRouted, ev.MustMarshal())
-		logger.Printf("[Orchestrator] published tasks.routed correlation=%s", corr)
+		logger.Info("tasks routed", "task_id", taskIDFromEvent(ev), "subject", bus.SubjectTasksRouted, "request_id", corr)
 	}, nats.Durable("orch-ui"), nats.ManualAck())
 
 	// Subscribe to plan (self-loop for demo - in real system Task Planner publishes)
@@ -92,7 +94,7 @@ func runOrchestrator(ctx context.Context, nc *nats.Conn, js nats.JetStreamContex
 		})
 		ev.SetCorrelationID(corr)
 		bus.PublishWithACL(js, comp, bus.SubjectTasksPlanCreated, ev.MustMarshal())
-		logger.Printf("[Orchestrator] published plan_created subtasks=3 correlation=%s", corr)
+		logger.Info("plan created", "subject", bus.SubjectTasksPlanCreated, "subtasks", 3, "request_id", corr)
 	}, nats.Durable("orch-router"), nats.ManualAck())
 
 	// Subscribe to plan_created, publish agents.created (queue group - FR-DB-004)
@@ -106,7 +108,7 @@ func runOrchestrator(ctx context.Context, nc *nats.Conn, js nats.JetStreamContex
 			ev.SetCorrelationID(corr)
 			bus.PublishWithACL(js, comp, bus.SubjectAgentsCreated, ev.MustMarshal())
 		}
-		logger.Printf("[Orchestrator] published agents.created x3 correlation=%s", corr)
+		logger.Info("agents created", "task_id", planCorr, "subject", bus.SubjectAgentsCreated, "count", 3, "request_id", corr)
 	}, nats.Durable("orch-agents"), nats.ManualAck())
 
 	<-ctx.Done()
@@ -114,12 +116,12 @@ func runOrchestrator(ctx context.Context, nc *nats.Conn, js nats.JetStreamContex
 }
 
 // runMemory simulates Memory & Context Manager.
-func runMemory(ctx context.Context, nc *nats.Conn, js nats.JetStreamContext, logger *log.Logger, comp string) {
+func runMemory(ctx context.Context, nc *nats.Conn, js nats.JetStreamContext, logger *slog.Logger, comp string) {
 	// FR-DB-002: Request-reply — Personalization responder (ACL enforced)
 	bus.SubscribeRequestReplyWithACL(ctx, nc, comp, bus.SubjectPersonalization, func(subject string, request []byte) ([]byte, error) {
 		_ = subject
 		_ = request
-		logger.Printf("[Memory] FR-DB-002 request-reply: handling personalization get")
+		logger.Info("personalization request received")
 		return json.Marshal(map[string]string{"userId": "demo-user", "preferences": "{}"})
 	})
 	time.Sleep(50 * time.Millisecond)
@@ -127,60 +129,63 @@ func runMemory(ctx context.Context, nc *nats.Conn, js nats.JetStreamContext, log
 	// Subscribe to agents.created, publish memory.saved
 	bus.SubscribeWithACL(js, comp, bus.SubjectAgentsCreated, func(m *nats.Msg) {
 		corr := extractCorr(m.Data)
+		taskID := extractTaskID(m.Data)
 		m.Ack()
 		ev := envelope.Build("aegis/memory", "aegis.memory.saved", map[string]string{
 			"agentId": envelope.NewID(),
 		})
 		ev.SetCorrelationID(corr)
 		bus.PublishWithACL(js, comp, bus.SubjectMemorySaved, ev.MustMarshal())
-		logger.Printf("[Memory] received agents.created, published memory.saved correlation=%s", corr)
+		logger.Info("memory saved", "task_id", taskID, "subject", bus.SubjectMemorySaved, "request_id", corr)
 	}, nats.Durable("memory-agents"), nats.ManualAck())
 
 	<-ctx.Done()
 }
 
 // runVault simulates Permission Manager / Vault.
-func runVault(ctx context.Context, nc *nats.Conn, js nats.JetStreamContext, logger *log.Logger, comp string) {
+func runVault(ctx context.Context, nc *nats.Conn, js nats.JetStreamContext, logger *slog.Logger, comp string) {
 	bus.SubscribeWithACL(js, comp, bus.SubjectVault, func(m *nats.Msg) {
 		corr := extractCorr(m.Data)
-		logger.Printf("[Vault] received subject=%s size=%d correlation=%s", m.Subject, len(m.Data), corr)
+		taskID := extractTaskID(m.Data)
+		logger.Info("vault message received", "task_id", taskID, "subject", m.Subject, "size_bytes", len(m.Data), "request_id", corr)
 		m.Ack()
 	}, nats.Durable("vault"), nats.ManualAck())
 	<-ctx.Done()
 }
 
 // runAgent simulates Agent runtime (Web Search, Doc Analysis, etc.).
-func runAgent(ctx context.Context, nc *nats.Conn, js nats.JetStreamContext, logger *log.Logger, comp string) {
+func runAgent(ctx context.Context, nc *nats.Conn, js nats.JetStreamContext, logger *slog.Logger, comp string) {
 	// EDD §9.2 / M3: sensitive subjects — Agents consumer group only (queue aegis-agents).
 	if _, err := bus.QueueSubscribeWithACL(js, comp, bus.SubjectAgentsVaultExecuteResult, security.QueueAgentsComponent, func(m *nats.Msg) {
 		m.Ack()
-		logger.Printf("[Agent] M3 received vault execute result subject=%s", m.Subject)
+		logger.Info("vault execute result received", "subject", m.Subject)
 	}, nats.Durable("agent-m3-vault-exec"), nats.ManualAck()); err != nil {
-		logger.Printf("[Agent] queue subscribe vault result: %v", err)
+		logger.Error("vault result queue subscribe failed", "error", err)
 	}
 	if _, err := bus.QueueSubscribeWithACL(js, comp, bus.SubjectAgentsCredentialResponse, security.QueueAgentsComponent, func(m *nats.Msg) {
 		m.Ack()
-		logger.Printf("[Agent] M3 received credential response subject=%s", m.Subject)
+		logger.Info("credential response received", "subject", m.Subject)
 	}, nats.Durable("agent-m3-cred"), nats.ManualAck()); err != nil {
-		logger.Printf("[Agent] queue subscribe credential response: %v", err)
+		logger.Error("credential response queue subscribe failed", "error", err)
 	}
 
 	bus.SubscribeWithACL(js, comp, bus.SubjectAgentsCreated, func(m *nats.Msg) {
 		corr := extractCorr(m.Data)
+		taskID := extractTaskID(m.Data)
 		m.Ack()
 		ev := envelope.Build("aegis/agent", "aegis.runtime.completed", map[string]string{
 			"agentId": envelope.NewID(), "result": "completed", "status": "ok",
 		})
 		ev.SetCorrelationID(corr)
 		bus.PublishWithACL(js, comp, bus.SubjectRuntimeCompleted, ev.MustMarshal())
-		logger.Printf("[Agent] received agents.created, published runtime.completed correlation=%s", corr)
+		logger.Info("runtime completed", "task_id", taskID, "subject", bus.SubjectRuntimeCompleted, "request_id", corr)
 	}, nats.Durable("agent-runtime"), nats.ManualAck())
 	<-ctx.Done()
 }
 
 // runMonitoring subscribes to all streams (FR-DB-005 wildcard per domain).
 // Uses SubjectAgentsLeafWildcard (aegis.agents.*) so M3 nested subjects are not observed here.
-func runMonitoring(ctx context.Context, nc *nats.Conn, js nats.JetStreamContext, logger *log.Logger, comp string) {
+func runMonitoring(ctx context.Context, nc *nats.Conn, js nats.JetStreamContext, logger *slog.Logger, comp string) {
 	var total uint64
 	subs := []struct {
 		subj string
@@ -204,7 +209,7 @@ func runMonitoring(ctx context.Context, nc *nats.Conn, js nats.JetStreamContext,
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			logger.Printf("[Monitoring] total_messages=%d", atomic.LoadUint64(&total))
+			logger.Info("monitoring summary", "total_messages", atomic.LoadUint64(&total))
 		}
 	}
 }
@@ -216,4 +221,25 @@ func extractCorr(data []byte) string {
 	}
 	s, _ := m["correlationid"].(string)
 	return s
+}
+
+func extractTaskID(data []byte) string {
+	var m map[string]interface{}
+	if json.Unmarshal(data, &m) != nil {
+		return ""
+	}
+	payload, _ := m["data"].(map[string]interface{})
+	if payload == nil {
+		return ""
+	}
+	taskID, _ := payload["taskId"].(string)
+	return taskID
+}
+
+func taskIDFromEvent(ev envelope.CloudEvent) string {
+	payload, _ := ev.Data.(map[string]string)
+	if payload == nil {
+		return ""
+	}
+	return payload["taskId"]
 }

--- a/aegis-databus/cmd/demo/main.go
+++ b/aegis-databus/cmd/demo/main.go
@@ -56,8 +56,8 @@ func main() {
 	defer cancel()
 
 	baseLogger := slog.New(slog.NewJSONHandler(os.Stdout, nil)).
-		With("service", "databus")
-	logger := baseLogger.With("component", "demo")
+		With("component", "databus")
+	logger := baseLogger.With("module", "demo")
 	url := os.Getenv("AEGIS_NATS_URL")
 	if url == "" {
 		url = defaultNatsURL
@@ -87,7 +87,7 @@ func main() {
 	for _, c := range components {
 		connName, aclName, run := c.name, c.acl, c.run
 		go func() {
-			componentLogger := baseLogger.With("component", aclName)
+			componentLogger := baseLogger.With("module", "demo-"+aclName)
 			nc, js, err := connectAs(ctx, connName, url, componentLogger)
 			if err != nil {
 				componentLogger.Error("connect failed", "conn_name", connName, "error", err)

--- a/aegis-databus/cmd/demo/main.go
+++ b/aegis-databus/cmd/demo/main.go
@@ -4,7 +4,7 @@ package main
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
@@ -16,7 +16,7 @@ import (
 
 const defaultNatsURL = "nats://127.0.0.1:4222"
 
-func connectAs(ctx context.Context, connName, url string, logger *log.Logger) (*nats.Conn, nats.JetStreamContext, error) {
+func connectAs(ctx context.Context, connName, url string, logger *slog.Logger) (*nats.Conn, nats.JetStreamContext, error) {
 	seed, _ := security.GetNKeyFromOpenBao(ctx, "aegis-demo")
 	if seed != "" {
 		nc, err := security.NewConnectionWithNKeySeedAndName(url, seed, connName)
@@ -55,7 +55,9 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logger := log.New(os.Stdout, "demo ", log.LstdFlags)
+	baseLogger := slog.New(slog.NewJSONHandler(os.Stdout, nil)).
+		With("service", "databus")
+	logger := baseLogger.With("component", "demo")
 	url := os.Getenv("AEGIS_NATS_URL")
 	if url == "" {
 		url = defaultNatsURL
@@ -63,7 +65,7 @@ func main() {
 
 	seed, _ := security.GetNKeyFromOpenBao(ctx, "aegis-demo")
 	if seed != "" {
-		logger.Println("connected with NKey (Zero Trust)")
+		logger.Info("connected with NKey", "mode", "zero-trust")
 	}
 
 	// Each component gets its own connection for distinct Grafana "Traffic by component" names.
@@ -71,7 +73,7 @@ func main() {
 	components := []struct {
 		name string
 		acl  string
-		run  func(context.Context, *nats.Conn, nats.JetStreamContext, *log.Logger, string)
+		run  func(context.Context, *nats.Conn, nats.JetStreamContext, *slog.Logger, string)
 	}{
 		{"aegis-io", "io", runIO},
 		{"aegis-orchestrator", "orchestrator", runOrchestrator},
@@ -81,17 +83,19 @@ func main() {
 		{"aegis-monitoring", "monitoring", runMonitoring},
 	}
 
-	logger.Println("Starting 6 components: I/O, Orchestrator, Memory, Vault, Agent, Monitoring")
+	logger.Info("starting demo components", "count", len(components))
 	for _, c := range components {
 		connName, aclName, run := c.name, c.acl, c.run
 		go func() {
-			nc, js, err := connectAs(ctx, connName, url, logger)
+			componentLogger := baseLogger.With("component", aclName)
+			nc, js, err := connectAs(ctx, connName, url, componentLogger)
 			if err != nil {
-				logger.Printf("[%s] connect failed: %v", connName, err)
+				componentLogger.Error("connect failed", "conn_name", connName, "error", err)
 				return
 			}
 			defer nc.Close()
-			run(ctx, nc, js, logger, aclName)
+			componentLogger.Info("component connected", "conn_name", connName)
+			run(ctx, nc, js, componentLogger, aclName)
 		}()
 	}
 	time.Sleep(500 * time.Millisecond) // allow connections to establish
@@ -99,6 +103,6 @@ func main() {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
 	<-sig
-	logger.Println("shutting down")
+	logger.Info("shutting down")
 	cancel()
 }

--- a/aegis-databus/cmd/memory-stub/main.go
+++ b/aegis-databus/cmd/memory-stub/main.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -20,6 +20,9 @@ import (
 const defaultAddr = ":8090"
 
 func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil)).
+		With("service", "databus", "component", "memory-stub")
+
 	mock := memory.NewMockMemoryClient()
 	ctx := context.Background()
 	seedDemo(ctx, mock)
@@ -49,9 +52,10 @@ func main() {
 	if addr == "" {
 		addr = defaultAddr
 	}
-	log.Printf("memory-stub listening on %s", addr)
+	logger.Info("memory stub listening", "addr", addr)
 	if err := http.ListenAndServe(addr, mux); err != nil {
-		log.Fatal(err)
+		logger.Error("memory stub failed", "error", err, "exit_code", 1)
+		os.Exit(1)
 	}
 }
 

--- a/aegis-databus/cmd/memory-stub/main.go
+++ b/aegis-databus/cmd/memory-stub/main.go
@@ -21,7 +21,7 @@ const defaultAddr = ":8090"
 
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil)).
-		With("service", "databus", "component", "memory-stub")
+		With("component", "databus", "module", "memory-stub")
 
 	mock := memory.NewMockMemoryClient()
 	ctx := context.Background()

--- a/aegis-databus/cmd/orchestrator-stub/main.go
+++ b/aegis-databus/cmd/orchestrator-stub/main.go
@@ -18,7 +18,7 @@ const (
 
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil)).
-		With("service", "databus", "component", "orchestrator-stub")
+		With("component", "databus", "module", "orchestrator-stub")
 
 	memoryURL := os.Getenv("AEGIS_MEMORY_URL")
 	if memoryURL == "" {

--- a/aegis-databus/cmd/orchestrator-stub/main.go
+++ b/aegis-databus/cmd/orchestrator-stub/main.go
@@ -3,7 +3,7 @@
 package main
 
 import (
-	"log"
+	"log/slog"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -17,6 +17,9 @@ const (
 )
 
 func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil)).
+		With("service", "databus", "component", "orchestrator-stub")
+
 	memoryURL := os.Getenv("AEGIS_MEMORY_URL")
 	if memoryURL == "" {
 		memoryURL = defaultMemoryURL
@@ -54,8 +57,9 @@ func main() {
 	if addr == "" {
 		addr = defaultAddr
 	}
-	log.Printf("orchestrator-stub listening on %s, forwarding to %s", addr, memoryURL)
+	logger.Info("orchestrator stub listening", "addr", addr, "memory_url", memoryURL)
 	if err := http.ListenAndServe(addr, mux); err != nil {
-		log.Fatal(err)
+		logger.Error("orchestrator stub failed", "error", err, "exit_code", 1)
+		os.Exit(1)
 	}
 }

--- a/aegis-databus/cmd/stubs/main.go
+++ b/aegis-databus/cmd/stubs/main.go
@@ -39,7 +39,7 @@ type CloudEvent struct {
 func main() {
 	ctx := context.Background()
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil)).
-		With("service", "databus", "component", "stubs")
+		With("component", "databus", "module", "stubs")
 
 	nc, js, err := connect(ctx, logger)
 	if err != nil {

--- a/aegis-databus/cmd/stubs/main.go
+++ b/aegis-databus/cmd/stubs/main.go
@@ -6,7 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
-	"log"
+	"log/slog"
 	"os"
 	"sync/atomic"
 	"time"
@@ -18,9 +18,9 @@ import (
 )
 
 const (
-	defaultNatsURL   = "nats://127.0.0.1:4222"
-	defaultInterval  = 2 * time.Second
-	monitorInterval  = 5 * time.Second
+	defaultNatsURL    = "nats://127.0.0.1:4222"
+	defaultInterval   = 2 * time.Second
+	monitorInterval   = 5 * time.Second
 	stubComponentName = "aegis-stubs"
 )
 
@@ -38,11 +38,13 @@ type CloudEvent struct {
 
 func main() {
 	ctx := context.Background()
-	logger := log.New(os.Stdout, "stubs ", log.LstdFlags)
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil)).
+		With("service", "databus", "component", "stubs")
 
 	nc, js, err := connect(ctx, logger)
 	if err != nil {
-		logger.Fatalf("connect failed: %v", err)
+		logger.Error("connect failed", "error", err, "exit_code", 1)
+		os.Exit(1)
 	}
 	defer nc.Drain()
 
@@ -55,7 +57,7 @@ func main() {
 	select {}
 }
 
-func connect(ctx context.Context, logger *log.Logger) (*nats.Conn, nats.JetStreamContext, error) {
+func connect(ctx context.Context, logger *slog.Logger) (*nats.Conn, nats.JetStreamContext, error) {
 	_ = ctx
 	url := os.Getenv("AEGIS_NATS_URL")
 	if url == "" {
@@ -87,7 +89,7 @@ func connect(ctx context.Context, logger *log.Logger) (*nats.Conn, nats.JetStrea
 	if err != nil {
 		return nil, nil, err
 	}
-	logger.Printf("connected nats url=%s", url)
+	logger.Info("connected to NATS", "url", url)
 	return nc, js, nil
 }
 
@@ -106,7 +108,7 @@ func nkeyAuthOption(seed string) (nats.Option, error) {
 	return nats.Nkey(pub, sign), nil
 }
 
-func runTaskRouter(ctx context.Context, logger *log.Logger, js nats.JetStreamContext) {
+func runTaskRouter(ctx context.Context, logger *slog.Logger, js nats.JetStreamContext) {
 	ticker := time.NewTicker(defaultInterval)
 	defer ticker.Stop()
 
@@ -132,27 +134,28 @@ func runTaskRouter(ctx context.Context, logger *log.Logger, js nats.JetStreamCon
 
 			data, err := json.Marshal(payload)
 			if err != nil {
-				logger.Printf("task-router marshal failed: %v", err)
+				logger.Error("task router marshal failed", "task_id", taskIDFromPayload(payload), "trace_id", payload.TraceID, "error", err)
 				continue
 			}
 
 			if _, err := bus.PublishWithACL(js, stubComponentName, bus.SubjectTasksRouted, data); err != nil {
-				logger.Printf("task-router publish failed subject=%s size=%d err=%v", bus.SubjectTasksRouted, len(data), err)
+				logger.Error("task router publish failed", "task_id", taskIDFromPayload(payload), "trace_id", payload.TraceID, "subject", bus.SubjectTasksRouted, "size_bytes", len(data), "error", err)
 				continue
 			}
-			logger.Printf("task-router published subject=%s size=%d correlation=%s", bus.SubjectTasksRouted, len(data), payload.CorrelationID)
+			logger.Info("task router published", "task_id", taskIDFromPayload(payload), "trace_id", payload.TraceID, "subject", bus.SubjectTasksRouted, "size_bytes", len(data), "request_id", payload.CorrelationID)
 		}
 	}
 }
 
-func runOrchestrator(ctx context.Context, logger *log.Logger, js nats.JetStreamContext) {
+func runOrchestrator(ctx context.Context, logger *slog.Logger, js nats.JetStreamContext) {
 	sub, err := bus.SubscribeWithACL(js, stubComponentName, bus.SubjectTasksRouted, func(msg *nats.Msg) {
 		correlation := extractCorrelationID(msg.Data)
 		traceID := extractTraceID(msg.Data)
+		taskID := extractTaskID(msg.Data)
 		if traceID == "" {
 			traceID = correlation
 		}
-		logger.Printf("orchestrator received subject=%s size=%d correlation=%s traceid=%s", msg.Subject, len(msg.Data), correlation, traceID)
+		logger.Info("orchestrator received", "task_id", taskID, "trace_id", traceID, "subject", msg.Subject, "size_bytes", len(msg.Data), "request_id", correlation)
 		msg.Ack()
 
 		payload := CloudEvent{
@@ -171,17 +174,17 @@ func runOrchestrator(ctx context.Context, logger *log.Logger, js nats.JetStreamC
 		}
 		data, err := json.Marshal(payload)
 		if err != nil {
-			logger.Printf("orchestrator marshal failed: %v", err)
+			logger.Error("orchestrator marshal failed", "task_id", taskIDFromPayload(payload), "trace_id", traceID, "error", err)
 			return
 		}
 		if _, err := bus.PublishWithACL(js, stubComponentName, bus.SubjectAgentsCreated, data); err != nil {
-			logger.Printf("orchestrator publish failed subject=%s size=%d err=%v", bus.SubjectAgentsCreated, len(data), err)
+			logger.Error("orchestrator publish failed", "task_id", taskIDFromPayload(payload), "trace_id", traceID, "subject", bus.SubjectAgentsCreated, "size_bytes", len(data), "error", err)
 			return
 		}
-		logger.Printf("orchestrator published subject=%s size=%d correlation=%s", bus.SubjectAgentsCreated, len(data), payload.CorrelationID)
+		logger.Info("orchestrator published", "task_id", taskIDFromPayload(payload), "trace_id", traceID, "subject", bus.SubjectAgentsCreated, "size_bytes", len(data), "request_id", payload.CorrelationID)
 	}, nats.Durable("orchestrator"), nats.ManualAck())
 	if err != nil {
-		logger.Printf("orchestrator subscribe failed: %v", err)
+		logger.Error("orchestrator subscribe failed", "error", err)
 		return
 	}
 	defer sub.Unsubscribe()
@@ -189,14 +192,15 @@ func runOrchestrator(ctx context.Context, logger *log.Logger, js nats.JetStreamC
 	<-ctx.Done()
 }
 
-func runAgentFactory(ctx context.Context, logger *log.Logger, js nats.JetStreamContext) {
+func runAgentFactory(ctx context.Context, logger *slog.Logger, js nats.JetStreamContext) {
 	sub, err := bus.SubscribeWithACL(js, stubComponentName, bus.SubjectAgentsCreated, func(msg *nats.Msg) {
 		correlation := extractCorrelationID(msg.Data)
 		traceID := extractTraceID(msg.Data)
+		taskID := extractTaskID(msg.Data)
 		if traceID == "" {
 			traceID = correlation
 		}
-		logger.Printf("agent-factory received subject=%s size=%d correlation=%s traceid=%s", msg.Subject, len(msg.Data), correlation, traceID)
+		logger.Info("agent factory received", "task_id", taskID, "trace_id", traceID, "subject", msg.Subject, "size_bytes", len(msg.Data), "request_id", correlation)
 		msg.Ack()
 
 		payload := CloudEvent{
@@ -215,17 +219,17 @@ func runAgentFactory(ctx context.Context, logger *log.Logger, js nats.JetStreamC
 		}
 		data, err := json.Marshal(payload)
 		if err != nil {
-			logger.Printf("agent-factory marshal failed: %v", err)
+			logger.Error("agent factory marshal failed", "trace_id", traceID, "error", err)
 			return
 		}
 		if _, err := bus.PublishWithACL(js, stubComponentName, bus.SubjectRuntimeCompleted, data); err != nil {
-			logger.Printf("agent-factory publish failed subject=%s size=%d err=%v", bus.SubjectRuntimeCompleted, len(data), err)
+			logger.Error("agent factory publish failed", "trace_id", traceID, "subject", bus.SubjectRuntimeCompleted, "size_bytes", len(data), "error", err)
 			return
 		}
-		logger.Printf("agent-factory published subject=%s size=%d correlation=%s", bus.SubjectRuntimeCompleted, len(data), payload.CorrelationID)
+		logger.Info("agent factory published", "trace_id", traceID, "subject", bus.SubjectRuntimeCompleted, "size_bytes", len(data), "request_id", payload.CorrelationID)
 	}, nats.Durable("agent-factory"), nats.ManualAck())
 	if err != nil {
-		logger.Printf("agent-factory subscribe failed: %v", err)
+		logger.Error("agent factory subscribe failed", "error", err)
 		return
 	}
 	defer sub.Unsubscribe()
@@ -233,18 +237,19 @@ func runAgentFactory(ctx context.Context, logger *log.Logger, js nats.JetStreamC
 	<-ctx.Done()
 }
 
-func runVault(ctx context.Context, logger *log.Logger, js nats.JetStreamContext) {
+func runVault(ctx context.Context, logger *slog.Logger, js nats.JetStreamContext) {
 	sub, err := bus.SubscribeWithACL(js, stubComponentName, bus.SubjectVault, func(msg *nats.Msg) {
 		correlation := extractCorrelationID(msg.Data)
 		traceID := extractTraceID(msg.Data)
+		taskID := extractTaskID(msg.Data)
 		if traceID == "" {
 			traceID = correlation
 		}
-		logger.Printf("vault received subject=%s size=%d correlation=%s traceid=%s", msg.Subject, len(msg.Data), correlation, traceID)
+		logger.Info("vault received", "task_id", taskID, "trace_id", traceID, "subject", msg.Subject, "size_bytes", len(msg.Data), "request_id", correlation)
 		msg.Ack()
 	}, nats.Durable("vault"), nats.ManualAck())
 	if err != nil {
-		logger.Printf("vault subscribe failed: %v", err)
+		logger.Error("vault subscribe failed", "error", err)
 		return
 	}
 	defer sub.Unsubscribe()
@@ -252,7 +257,7 @@ func runVault(ctx context.Context, logger *log.Logger, js nats.JetStreamContext)
 	<-ctx.Done()
 }
 
-func runMonitoring(ctx context.Context, logger *log.Logger, js nats.JetStreamContext) {
+func runMonitoring(ctx context.Context, logger *slog.Logger, js nats.JetStreamContext) {
 	var total uint64
 	type subDef struct{ subj, dura string }
 	for _, s := range []subDef{
@@ -264,7 +269,7 @@ func runMonitoring(ctx context.Context, logger *log.Logger, js nats.JetStreamCon
 			msg.Ack()
 		}, nats.Durable(s.dura), nats.ManualAck())
 		if err != nil {
-			logger.Printf("monitoring subscribe %s failed: %v", s.subj, err)
+			logger.Error("monitoring subscribe failed", "subject", s.subj, "error", err)
 			continue
 		}
 		defer sub.Unsubscribe()
@@ -278,7 +283,7 @@ func runMonitoring(ctx context.Context, logger *log.Logger, js nats.JetStreamCon
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			logger.Printf("monitoring summary total_messages=%d", atomic.LoadUint64(&total))
+			logger.Info("monitoring summary", "total_messages", atomic.LoadUint64(&total))
 		}
 	}
 }
@@ -299,6 +304,27 @@ func extractTraceID(payload []byte) string {
 	}
 	raw, _ := msg["traceid"].(string)
 	return raw
+}
+
+func extractTaskID(payload []byte) string {
+	var msg map[string]interface{}
+	if err := json.Unmarshal(payload, &msg); err != nil {
+		return ""
+	}
+	data, _ := msg["data"].(map[string]interface{})
+	if data == nil {
+		return ""
+	}
+	raw, _ := data["taskId"].(string)
+	return raw
+}
+
+func taskIDFromPayload(payload CloudEvent) string {
+	data, _ := payload.Data.(map[string]string)
+	if data == nil {
+		return ""
+	}
+	return data["taskId"]
 }
 
 // traceID32Hex returns 32 lowercase hex chars (W3C trace_id length).

--- a/aegis-databus/internal/dlq/replay.go
+++ b/aegis-databus/internal/dlq/replay.go
@@ -33,7 +33,7 @@ func (h *ReplayHandler) Start(ctx context.Context) {
 	}
 	if h.Logger == nil {
 		h.Logger = slog.New(slog.NewJSONHandler(os.Stdout, nil)).
-			With("service", "databus", "component", "dlq-replay")
+			With("component", "databus", "module", "dlq-replay")
 	}
 	logger := h.Logger
 	component := h.Component

--- a/aegis-databus/internal/dlq/replay.go
+++ b/aegis-databus/internal/dlq/replay.go
@@ -2,7 +2,8 @@ package dlq
 
 import (
 	"context"
-	"log"
+	"log/slog"
+	"os"
 	"strings"
 
 	"aegis-databus/pkg/bus"
@@ -19,9 +20,9 @@ import (
 //
 // Consumers should use bus.ForwardToDLQ when sending to DLQ so X-Aegis-Original-Subject is set.
 type ReplayHandler struct {
-	JS       nats.JetStreamContext
-	Checker  memory.IdempotencyChecker // optional: if nil, always replay
-	Logger   *log.Logger
+	JS        nats.JetStreamContext
+	Checker   memory.IdempotencyChecker // optional: if nil, always replay
+	Logger    *slog.Logger
 	Component string // for ACL, e.g. "aegis-databus"
 }
 
@@ -31,8 +32,10 @@ func (h *ReplayHandler) Start(ctx context.Context) {
 		return
 	}
 	if h.Logger == nil {
-		h.Logger = log.Default()
+		h.Logger = slog.New(slog.NewJSONHandler(os.Stdout, nil)).
+			With("service", "databus", "component", "dlq-replay")
 	}
+	logger := h.Logger
 	component := h.Component
 	if component == "" {
 		component = "aegis-databus"
@@ -41,7 +44,7 @@ func (h *ReplayHandler) Start(ctx context.Context) {
 	_, err := bus.SubscribeWithACL(h.JS, component, bus.SubjectDLQ, func(m *nats.Msg) {
 		originalSubject := m.Header.Get(bus.HeaderOriginalSubject)
 		if originalSubject == "" {
-			h.Logger.Printf("dlq-replay: missing %s, discarding (ack)", bus.HeaderOriginalSubject)
+			logger.Warn("dlq original subject missing, discarding", "header", bus.HeaderOriginalSubject)
 			m.Ack()
 			return
 		}
@@ -50,9 +53,9 @@ func (h *ReplayHandler) Start(ctx context.Context) {
 		if h.Checker != nil && msgID != "" {
 			done, err := h.Checker.WasProcessed(ctx, msgID)
 			if err != nil {
-				h.Logger.Printf("dlq-replay: WasProcessed id=%s err=%v, will replay", msgID, err)
+				logger.Warn("dlq idempotency check failed, will replay", "message_id", msgID, "error", err)
 			} else if done {
-				h.Logger.Printf("dlq-replay: id=%s already processed, skipping replay", msgID)
+				logger.Info("dlq message already processed, skipping replay", "message_id", msgID)
 				m.Ack()
 				return
 			}
@@ -61,7 +64,7 @@ func (h *ReplayHandler) Start(ctx context.Context) {
 		// Republish with MsgId for 120s dedup (same id republished within window is dropped)
 		_, err := bus.PublishWithMsgID(h.JS, originalSubject, m.Data, msgID)
 		if err != nil {
-			h.Logger.Printf("dlq-replay: republish subject=%s id=%s err=%v", originalSubject, msgID, err)
+			logger.Error("dlq republish failed", "subject", originalSubject, "message_id", msgID, "error", err)
 			m.Nak()
 			return
 		}
@@ -69,12 +72,12 @@ func (h *ReplayHandler) Start(ctx context.Context) {
 		if h.Checker != nil && msgID != "" {
 			_ = h.Checker.RecordProcessed(ctx, msgID)
 		}
-		h.Logger.Printf("dlq-replay: replayed subject=%s id=%s", originalSubject, msgID)
+		logger.Info("dlq message replayed", "subject", originalSubject, "message_id", msgID)
 		m.Ack()
 	}, nats.Durable("dlq-replay"), nats.ManualAck())
 
 	if err != nil {
-		h.Logger.Printf("dlq-replay: subscribe failed: %v", err)
+		logger.Error("dlq subscribe failed", "error", err)
 		return
 	}
 

--- a/aegis-databus/internal/health/heartbeat.go
+++ b/aegis-databus/internal/health/heartbeat.go
@@ -23,7 +23,7 @@ type Heartbeat struct {
 func NewHeartbeat(nc *nats.Conn, logger *slog.Logger) *Heartbeat {
 	if logger == nil {
 		logger = slog.New(slog.NewJSONHandler(os.Stdout, nil)).
-			With("service", "databus", "component", "health-heartbeat")
+			With("component", "databus", "module", "health-heartbeat")
 	}
 	return &Heartbeat{nc: nc, logger: logger}
 }

--- a/aegis-databus/internal/health/heartbeat.go
+++ b/aegis-databus/internal/health/heartbeat.go
@@ -3,7 +3,8 @@ package health
 import (
 	"context"
 	"encoding/json"
-	"log"
+	"log/slog"
+	"os"
 	"time"
 
 	"aegis-databus/internal/metrics"
@@ -16,12 +17,13 @@ const interval = 5 * time.Second
 // Heartbeat publishes aegis.health.databus status for Self-Healing to monitor.
 type Heartbeat struct {
 	nc     *nats.Conn
-	logger *log.Logger
+	logger *slog.Logger
 }
 
-func NewHeartbeat(nc *nats.Conn, logger *log.Logger) *Heartbeat {
+func NewHeartbeat(nc *nats.Conn, logger *slog.Logger) *Heartbeat {
 	if logger == nil {
-		logger = log.Default()
+		logger = slog.New(slog.NewJSONHandler(os.Stdout, nil)).
+			With("service", "databus", "component", "health-heartbeat")
 	}
 	return &Heartbeat{nc: nc, logger: logger}
 }
@@ -41,7 +43,7 @@ func (h *Heartbeat) Start(ctx context.Context) {
 				"time":      time.Now().UTC().Format(time.RFC3339Nano),
 			})
 			if err := h.nc.Publish(bus.SubjectHealthDatabus, payload); err != nil {
-				h.logger.Printf("heartbeat publish failed: %v", err)
+				h.logger.Warn("heartbeat publish failed", "subject", bus.SubjectHealthDatabus, "error", err)
 			} else {
 				metrics.HeartbeatsPublished.Inc()
 			}

--- a/aegis-databus/internal/health/heartbeat_test.go
+++ b/aegis-databus/internal/health/heartbeat_test.go
@@ -2,7 +2,8 @@ package health
 
 import (
 	"context"
-	"log"
+	"io"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 )
 
 func TestNewHeartbeat(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	hb := NewHeartbeat(nil, nil)
 	if hb == nil {
 		t.Fatal("NewHeartbeat returned nil")
@@ -19,8 +21,8 @@ func TestNewHeartbeat(t *testing.T) {
 		t.Error("logger should be set when nil passed")
 	}
 
-	hb2 := NewHeartbeat(nil, log.Default())
-	if hb2.logger != log.Default() {
+	hb2 := NewHeartbeat(nil, logger)
+	if hb2.logger != logger {
 		t.Error("logger should use provided value")
 	}
 }
@@ -40,7 +42,7 @@ func TestHeartbeat_Start(t *testing.T) {
 	}
 	defer nc.Close()
 
-	hb := NewHeartbeat(nc, log.New(nil, "", 0))
+	hb := NewHeartbeat(nc, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	runCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	done := make(chan struct{})

--- a/aegis-databus/internal/heartbeat/heartbeat.go
+++ b/aegis-databus/internal/heartbeat/heartbeat.go
@@ -76,7 +76,7 @@ func New(nc *nats.Conn, service string, log *slog.Logger) *Emitter {
 		hostname:   host,
 		pid:        pid,
 		subject:    SubjectPrefix + service,
-		log:        log.With("component", "heartbeat", "service", service),
+		log:        log.With("module", "heartbeat"),
 		interval:   DefaultInterval,
 		startedAt:  time.Now().UTC(),
 	}

--- a/aegis-databus/internal/jetstreammetrics/poller.go
+++ b/aegis-databus/internal/jetstreammetrics/poller.go
@@ -2,7 +2,7 @@ package jetstreammetrics
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"os"
 	"time"
 
@@ -16,7 +16,7 @@ const DefaultPollInterval = 30 * time.Second
 
 // Start runs a background loop that updates Prometheus gauges from JetStream StreamInfo
 // until ctx is done.
-func Start(ctx context.Context, nc *nats.Conn, interval time.Duration, logger *log.Logger) {
+func Start(ctx context.Context, nc *nats.Conn, interval time.Duration, logger *slog.Logger) {
 	if nc == nil {
 		return
 	}
@@ -24,11 +24,12 @@ func Start(ctx context.Context, nc *nats.Conn, interval time.Duration, logger *l
 		interval = DefaultPollInterval
 	}
 	if logger == nil {
-		logger = log.New(os.Stdout, "jetstream-metrics ", log.LstdFlags)
+		logger = slog.New(slog.NewJSONHandler(os.Stdout, nil)).
+			With("service", "databus", "component", "jetstream-metrics")
 	}
 	js, err := nc.JetStream()
 	if err != nil {
-		logger.Printf("JetStream: %v", err)
+		logger.Error("jetstream context failed", "error", err)
 		return
 	}
 
@@ -40,7 +41,7 @@ func Start(ctx context.Context, nc *nats.Conn, interval time.Duration, logger *l
 			info, err := js.StreamInfo(name)
 			if err != nil {
 				metrics.JetStreamPollErrors.Inc()
-				logger.Printf("StreamInfo %s: %v", name, err)
+				logger.Warn("stream info failed", "stream", name, "error", err)
 				continue
 			}
 			if info == nil {

--- a/aegis-databus/internal/jetstreammetrics/poller.go
+++ b/aegis-databus/internal/jetstreammetrics/poller.go
@@ -25,7 +25,7 @@ func Start(ctx context.Context, nc *nats.Conn, interval time.Duration, logger *s
 	}
 	if logger == nil {
 		logger = slog.New(slog.NewJSONHandler(os.Stdout, nil)).
-			With("service", "databus", "component", "jetstream-metrics")
+			With("component", "databus", "module", "jetstream-metrics")
 	}
 	js, err := nc.JetStream()
 	if err != nil {

--- a/aegis-databus/internal/relay/outbox.go
+++ b/aegis-databus/internal/relay/outbox.go
@@ -3,7 +3,7 @@ package relay
 import (
 	"context"
 	"errors"
-	"log"
+	"log/slog"
 	"os"
 	"time"
 
@@ -29,7 +29,7 @@ type OutboxRelay struct {
 	MemoryClient memory.MemoryClient
 	PollInterval time.Duration
 	MaxBatch     int
-	Logger       *log.Logger
+	Logger       *slog.Logger
 }
 
 func (r *OutboxRelay) Start(ctx context.Context) {
@@ -44,8 +44,10 @@ func (r *OutboxRelay) Start(ctx context.Context) {
 		r.MaxBatch = 100
 	}
 	if r.Logger == nil {
-		r.Logger = log.New(os.Stdout, "outbox-relay ", log.LstdFlags)
+		r.Logger = slog.New(slog.NewJSONHandler(os.Stdout, nil)).
+			With("service", "databus", "component", "outbox-relay")
 	}
+	logger := r.Logger
 
 	ticker := time.NewTicker(r.PollInterval)
 	defer ticker.Stop()
@@ -56,7 +58,7 @@ func (r *OutboxRelay) Start(ctx context.Context) {
 	doFetch := func() {
 		entries, err := r.MemoryClient.FetchPendingOutbox(ctx, r.MaxBatch)
 		if err != nil {
-			r.Logger.Printf("fetch failed: %v", err)
+			logger.Error("outbox fetch failed", "error", err)
 			if !sleepWithContext(ctx, backoff) {
 				return
 			}
@@ -84,20 +86,20 @@ func (r *OutboxRelay) Start(ctx context.Context) {
 			}
 			span.End()
 			if err != nil {
-				r.Logger.Printf("publish failed subject=%s size=%d attempt=%d err=%v",
-					entry.Subject,
-					len(entry.Payload),
-					entry.AttemptCount+1,
-					err,
+				logger.Error("outbox publish failed",
+					"subject", entry.Subject,
+					"size_bytes", len(entry.Payload),
+					"attempt", entry.AttemptCount+1,
+					"error", err,
 				)
 				if updateErr := r.applyPublishFailure(ctx, entry); updateErr != nil {
-					r.Logger.Printf("update failed id=%s err=%v", entry.ID, updateErr)
+					logger.Error("outbox update failed", "entry_id", entry.ID, "error", updateErr)
 				}
 				continue
 			}
 
 			if err := r.MemoryClient.MarkOutboxSent(ctx, entry.ID, ack.Sequence); err != nil {
-				r.Logger.Printf("mark sent failed id=%s err=%v", entry.ID, err)
+				logger.Error("outbox mark sent failed", "entry_id", entry.ID, "error", err)
 			} else {
 				metrics.OutboxRelayProcessed.Inc()
 				// Audit log: metadata only, no payload (SR-DB-005); traceid for Design Principle 4

--- a/aegis-databus/internal/relay/outbox.go
+++ b/aegis-databus/internal/relay/outbox.go
@@ -45,7 +45,7 @@ func (r *OutboxRelay) Start(ctx context.Context) {
 	}
 	if r.Logger == nil {
 		r.Logger = slog.New(slog.NewJSONHandler(os.Stdout, nil)).
-			With("service", "databus", "component", "outbox-relay")
+			With("component", "databus", "module", "outbox-relay")
 	}
 	logger := r.Logger
 

--- a/agents-component/cmd/aegis-agents/main.go
+++ b/agents-component/cmd/aegis-agents/main.go
@@ -31,7 +31,7 @@ import (
 
 func main() {
 	log := slog.New(slog.NewJSONHandler(os.Stdout, nil)).
-		With("service", "agents", "component", "aegis-agents")
+		With("component", "agents", "module", "aegis-agents")
 	slog.SetDefault(log)
 
 	cfg, err := config.Load()

--- a/agents-component/cmd/aegis-agents/main.go
+++ b/agents-component/cmd/aegis-agents/main.go
@@ -32,10 +32,11 @@ import (
 func main() {
 	log := slog.New(slog.NewJSONHandler(os.Stdout, nil)).
 		With("service", "agents", "component", "aegis-agents")
+	slog.SetDefault(log)
 
 	cfg, err := config.Load()
 	if err != nil {
-		log.Error("config load failed", "error", err)
+		log.Error("config load failed", "error", err, "exit_code", 1)
 		os.Exit(1)
 	}
 

--- a/agents-component/cmd/agent-process/loop.go
+++ b/agents-component/cmd/agent-process/loop.go
@@ -254,7 +254,7 @@ func RunLoop(ctx context.Context, log *slog.Logger, spawnCtx *SpawnContext, ve *
 					// so the next task in this conversation includes the full exchange.
 					history = append(history, resp.ToParam())
 					if err := sl.WriteConversationSnapshot(spawnCtx.ConversationID, spawnCtx.TaskID, history, totalTokens); err != nil {
-						log.Warn("conversation snapshot write failed", "error", err, "conversation_id", spawnCtx.ConversationID)
+						log.Warn("conversation snapshot write failed", "error", err)
 					}
 					return block.Text, history, nil
 				}
@@ -279,7 +279,7 @@ func RunLoop(ctx context.Context, log *slog.Logger, spawnCtx *SpawnContext, ve *
 					attemptSkillSynthesis(ctx, client, log, spawnCtx, sl, history, toolCallCount)
 					history = append(history, resp.ToParam())
 					if err := sl.WriteConversationSnapshot(spawnCtx.ConversationID, spawnCtx.TaskID, history, totalTokens); err != nil {
-						log.Warn("conversation snapshot write failed", "error", err, "conversation_id", spawnCtx.ConversationID)
+						log.Warn("conversation snapshot write failed", "error", err)
 					}
 					const truncationNotice = "\n\n_[Response truncated — output token limit reached. Send a follow-up message to continue.]_"
 					return block.Text + truncationNotice, history, nil
@@ -482,7 +482,7 @@ func RunLoop(ctx context.Context, log *slog.Logger, spawnCtx *SpawnContext, ve *
 			}
 
 			if err := sl.WriteConversationSnapshot(spawnCtx.ConversationID, spawnCtx.TaskID, history, totalTokens); err != nil {
-				log.Warn("conversation snapshot write failed", "error", err, "conversation_id", spawnCtx.ConversationID)
+				log.Warn("conversation snapshot write failed", "error", err)
 			}
 			return finalResult, history, nil
 		}

--- a/agents-component/cmd/agent-process/main.go
+++ b/agents-component/cmd/agent-process/main.go
@@ -105,7 +105,7 @@ type TaskOutput struct {
 
 func main() {
 	rootLog := slog.New(slog.NewJSONHandler(os.Stderr, nil)).
-		With("service", "agents", "component", "agent-process")
+		With("component", "agents", "module", "agent-process")
 	slog.SetDefault(rootLog)
 
 	rootCtx, cancel := context.WithCancel(context.Background())
@@ -238,6 +238,9 @@ var mmdsDelivered bool
 // framing and output are always written to stdout regardless of error.
 func runOneTask(rootCtx context.Context, rootLog *slog.Logger, spawnCtx *SpawnContext, specBudget *skills.SpecBudget, encoder *json.Encoder, priorTurns []anthropic.MessageParam) ([]anthropic.MessageParam, error) {
 	log := rootLog.With("task_id", spawnCtx.TaskID, "trace_id", spawnCtx.TraceID)
+	if spawnCtx.ConversationID != "" {
+		log = log.With("conversation_id", spawnCtx.ConversationID)
+	}
 
 	if err := validate(spawnCtx); err != nil {
 		writeError(log, spawnCtx.TaskID, spawnCtx.TraceID, err.Error())

--- a/agents-component/cmd/agent-process/main.go
+++ b/agents-component/cmd/agent-process/main.go
@@ -106,6 +106,7 @@ type TaskOutput struct {
 func main() {
 	rootLog := slog.New(slog.NewJSONHandler(os.Stderr, nil)).
 		With("service", "agents", "component", "agent-process")
+	slog.SetDefault(rootLog)
 
 	rootCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/agents-component/cmd/agent-process/session.go
+++ b/agents-component/cmd/agent-process/session.go
@@ -369,7 +369,6 @@ func (sl *SessionLog) WriteConversationSnapshot(conversationID, taskID string, h
 		return fmt.Errorf("session log: conversation snapshot: publish: %w", err)
 	}
 	sl.log.Info("session log: conversation snapshot written",
-		"conversation_id", conversationID,
 		"turn_count", len(turns),
 		"total_tokens", totalTokens,
 	)

--- a/agents-component/cmd/simulator/main.go
+++ b/agents-component/cmd/simulator/main.go
@@ -329,7 +329,8 @@ func newID() string {
 // ── main ──────────────────────────────────────────────────────────────────────
 
 func main() {
-	log := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	log := slog.New(slog.NewJSONHandler(os.Stdout, nil)).
+		With("component", "agents", "module", "simulator")
 
 	natsURL := os.Getenv("AEGIS_NATS_URL")
 	if natsURL == "" {

--- a/agents-component/internal/heartbeat/heartbeat.go
+++ b/agents-component/internal/heartbeat/heartbeat.go
@@ -71,7 +71,7 @@ func New(nc *nats.Conn, service string, log *slog.Logger) *Emitter {
 		hostname:   host,
 		pid:        pid,
 		subject:    SubjectPrefix + service,
-		log:        log.With("component", "heartbeat", "service", service),
+		log:        log.With("module", "heartbeat"),
 		interval:   DefaultInterval,
 		startedAt:  time.Now().UTC(),
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,7 @@ services:
       STT_PROVIDER: disabled
       MEMORY_API_BASE: http://memory-api:8081
       OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4318
-      OTEL_SERVICE_NAME: io-api
+      OTEL_SERVICE_NAME: io
     restart: unless-stopped
     networks:
       - cerberos
@@ -154,7 +154,7 @@ services:
       NATS_URL: nats://nats:4222
       # Observability: OTLP HTTP trace export to Tempo (same pattern as io-api).
       OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4318
-      OTEL_SERVICE_NAME: memory-api
+      OTEL_SERVICE_NAME: memory
     ports:
       - "8081:8081"
     restart: unless-stopped
@@ -219,7 +219,7 @@ services:
       AEGIS_MEMORY_URL: http://memory-api:8081/v1/memory
       # Observability: OTLP HTTP export (databus uses otlptracehttp in pkg/telemetry).
       OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4318
-      OTEL_SERVICE_NAME: aegis-databus
+      OTEL_SERVICE_NAME: databus
     ports:
       - "9091:9091"
     healthcheck:
@@ -335,7 +335,7 @@ services:
       AEGIS_NATS_URL: nats://nats:4222
       # Observability: OTLP HTTP trace export (safe no-op if not using tracing here).
       OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4318
-      OTEL_SERVICE_NAME: aegis-simulator
+      OTEL_SERVICE_NAME: agents
     restart: unless-stopped
     networks:
       - cerberos
@@ -373,7 +373,7 @@ services:
       # Observability: OTLP HTTP export continues the trace from Orchestrator
       # via TaskSpec.TraceID. Disabled automatically when endpoint is unset.
       OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4318
-      OTEL_SERVICE_NAME: aegis-agents
+      OTEL_SERVICE_NAME: agents
     ports:
       - "9190:9090"
     restart: unless-stopped

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -4,12 +4,34 @@ All runtime components emit **structured JSON logs**, one object per line, using
 the same schema. Logs go to stdout except for `agents-component/cmd/agent-process`,
 which writes logs to stderr because stdout carries the JSON task protocol.
 
+## Components
+
+cerberOS has exactly **six** components, named after the top-level folders that
+own them. The `component` field on every log line is one of these values, and
+nothing else:
+
+| `component` | Folder | Description |
+|-------------|--------|-------------|
+| `agents` | `agents-component/` | Agent supervisor and `agent-process` workers |
+| `orchestrator` | `orchestrator/` | Task router, planner, monitor, recovery |
+| `io` | `io/` | API gateway, core engine, web/cli surfaces |
+| `memory` | `memory/` | Memory store and retrieval service |
+| `vault` | `vault/` | Credential vault and OpenBao broker |
+| `databus` | `aegis-databus/` | NATS JetStream message bus |
+
+A binary always identifies itself with the component that owns it. Sub-units
+inside a component (server, http, dispatcher, outbox-relay, surface adapter,
+heartbeat emitter, etc.) go in the **`module`** field, never in `component`.
+
+There is **no** `service` field. The previous `service` field has been removed
+because it duplicated `component` and produced confusing labels in Loki.
+
 ## Canonical Schema
 
 Every log line uses this field order:
 
-1. Required base fields: `time`, `level`, `msg`, `service`, `component`
-2. Correlation fields: `task_id`, `trace_id`, `request_id`, `message_id` when applicable
+1. Required base fields: `time`, `level`, `msg`, `component`, `module`
+2. Correlation fields: `task_id`, `conversation_id`, `trace_id`, `request_id`, `message_id` when applicable
 3. Safe component-specific fields
 
 | Field | Type | Required | Notes |
@@ -17,9 +39,10 @@ Every log line uses this field order:
 | `time` | string | yes | RFC3339Nano or ISO-8601 UTC timestamp |
 | `level` | string | yes | `DEBUG` `INFO` `WARN` `ERROR` |
 | `msg` | string | yes | Short event name or sentence; no trailing period |
-| `service` | string | yes | Fixed per binary; see table below |
-| `component` | string | yes | Sub-package or logical unit within the service |
+| `component` | string | yes | One of the six components above |
+| `module` | string | yes | Sub-unit within the component (e.g. `server`, `dispatcher`, `http`) |
 | `task_id` | string | task logs | Required while handling or routing a task |
+| `conversation_id` | string | conversation logs | Stable thread ID; required when a log line pertains to a chat conversation (chat task, snapshot, message), absent otherwise |
 | `trace_id` | string | traced logs | W3C 32-hex trace ID; required when available in context |
 | `request_id` | string | request logs | Vault execute, HTTP, NATS, or component request ID |
 | `message_id` | string | message logs | NATS/envelope message ID when available |
@@ -28,20 +51,67 @@ Additional key-value pairs append after the canonical fields. They must be safe
 metadata, never raw payloads, raw user input, credentials, permission tokens, or
 operation results.
 
-## Service Names
+### task_id vs conversation_id
 
-| Binary | `service` value |
-|--------|----------------|
-| `vault/engine` | `vault` |
-| `aegis-databus` | `databus` |
-| `agents-component/cmd/aegis-agents` | `agents` |
-| `agents-component/cmd/agent-process` | `agents` |
-| `memory` | `memory` |
-| `orchestrator` | `orchestrator` |
-| `io/api` | `io-api` |
-| `io/core` | `io-core` |
-| `io/surfaces/web` | `io-web` |
-| `io/surfaces/cli` | `io-cli` |
+A `conversation_id` is the long-lived ID of a chat thread; a `task_id` is one
+agent run inside that thread. One conversation can produce many tasks. Both
+are correlation keys, but they answer different debugging questions:
+
+- `task_id` — "what happened during this single run?"
+- `conversation_id` — "what happened across every run in this thread?"
+
+Within a single run, `trace_id` already covers end-to-end stitching across all
+components, so for one-task debugging `trace_id` is sufficient and `conversation_id`
+is redundant. `conversation_id` becomes the load-bearing key when a debugger
+needs to widen across multiple tasks in the same thread.
+
+### Why `vault` and `databus` logs do not carry `conversation_id`
+
+`vault` and `databus` only see envelope-level metadata — they never crack open
+the user-task payload — so neither receives `conversation_id` on the wire today.
+Their logs include `trace_id`, `task_id`, `request_id`, and `message_id` as
+applicable, but not `conversation_id`. This is a deliberate scope choice, not
+an oversight.
+
+The mapping is recoverable from persistent state: `chat_schema.tasks` in the
+Memory component records `(task_id, conversation_id, trace_id)` on the same row,
+so a debugger can resolve `trace_id → conversation_id` with a single query and
+then widen the search across the rest of the components. When that two-step
+becomes a recurring pain point, `conversation_id` can be added to the
+`CloudEvent` envelope and the vault/credential request payloads — at which
+point this section should be removed.
+
+## Module Names
+
+Modules are free-form within a component but should be stable, descriptive, and
+lowercase-with-dashes. Common modules per component:
+
+| Component | Typical modules |
+|-----------|-----------------|
+| `agents` | `aegis-agents`, `agent-process`, `heartbeat`, `simulator` |
+| `orchestrator` | `main`, `server`, `dispatcher`, `task_dispatcher`, `task_monitor`, `plan_executor`, `comms_gateway`, `recovery`, `heartbeat_emitter`, `heartbeat_sweeper`, `io-client` |
+| `io` | `server`, `http`, `nats`, `transcription`, `voice`, `credential`, `trace`, `heartbeat`, `memory-client`, `orchestrator-proxy`, `web-surface-adapter`, `web-surface-factory`, `cli`, `cli-surface-adapter`, `cli-session-store` |
+| `memory` | `server`, `heartbeat` |
+| `vault` | `server`, `heartbeat` |
+| `databus` | `server`, `outbox-relay`, `dlq-replay`, `health-heartbeat`, `jetstream-metrics`, `orchestrator-stub`, `memory-stub`, `stubs`, `demo` |
+
+### Naming rule: never reuse a component name as a module
+
+A `module` value MUST NOT equal any of the six component names. A log line
+that says `component=io, module=orchestrator` is confusing because readers
+cannot tell whether the entry belongs to the `io` component or to the
+`orchestrator` component.
+
+If a sub-unit relates to another component (for example, the layer in `io`
+that proxies to the orchestrator), encode the relationship in the module
+name: `orchestrator-proxy`, `orchestrator-stub`, `orchestrator-client`,
+`io-client`, `memory-client`, etc. Component names may appear *inside* a
+compound module name, but never on their own.
+
+When a binary embeds another component's identity (for example, the databus
+demo simulates an orchestrator stub), the `component` is still the host
+binary's component (`databus`) and the simulation goes in `module`
+(`orchestrator-stub`, never bare `orchestrator`).
 
 ## Level Semantics
 
@@ -78,7 +148,9 @@ format:
 - Error paths
 
 Task-handling logs must include `task_id`. If trace context is available, include
-`trace_id` on the same log line.
+`trace_id` on the same log line. Logs that pertain to a chat conversation
+(chat tasks, conversation snapshots, message persistence) must additionally
+include `conversation_id` whenever the value is in scope.
 
 ## Out of Scope
 
@@ -93,21 +165,29 @@ The logging standard does not apply to:
 ## Loki and Grafana
 
 Promtail parses the canonical JSON fields before pushing logs to Loki. The
-bounded-cardinality fields `service`, `component`, and `level` are promoted to
+bounded-cardinality fields `component`, `module`, and `level` are promoted to
 Loki labels so Grafana can filter component logs efficiently.
 
-High-cardinality correlation fields such as `task_id`, `trace_id`, `request_id`,
-and `message_id` remain in the JSON log body. Query them with LogQL JSON parsing:
+High-cardinality correlation fields such as `task_id`, `conversation_id`,
+`trace_id`, `request_id`, and `message_id` remain in the JSON log body. Query
+them with LogQL JSON parsing:
 
 ```logql
-{job="docker", service="orchestrator"} | json | task_id="task-123"
+{job="docker", component="orchestrator"} | json | task_id="task-123"
+{job="docker", component=~"orchestrator|agents|io|memory"} | json | conversation_id="conv-abc"
 ```
 
 Use the bundled Grafana dashboard `CerberOS — container logs` to view all
 component logs:
 
 ```logql
-{job="docker", service=~".+"}
+{job="docker", component=~".+"}
+```
+
+To narrow to a single sub-unit:
+
+```logql
+{job="docker", component="memory", module="server"}
 ```
 
 ## Go Usage
@@ -115,12 +195,12 @@ component logs:
 ```go
 // Initialise once in main():
 logger := slog.New(slog.NewJSONHandler(os.Stdout, nil)).
-    With("service", "myservice", "component", "server")
+    With("component", "memory", "module", "server")
 
 // Normal log
 logger.Info("server started", "addr", ":8080")
 
-// Fatal (log + exit)
+// Unrecoverable failure (log + exit)
 logger.Error("config load failed", "error", err, "exit_code", 1)
 os.Exit(1)
 
@@ -128,26 +208,36 @@ os.Exit(1)
 logger.Info("request received", "task_id", taskID, "trace_id", traceID, "method", r.Method)
 ```
 
+For the orchestrator, use the helpers in `orchestrator/internal/observability`:
+
+```go
+log := observability.LoggerWithModule("dispatcher")
+log.Info("task dispatched", "task_id", taskID)
+
+// or pull all IDs from context:
+observability.LogFromContext(ctx).Info("task dispatched")
+```
+
 ## TypeScript Usage (io/* services)
 
 ```typescript
 import { ioLog, logFromContext } from './logger'
 
-// Without request context
+// Without request context (component is always "io"; second arg is the module)
 ioLog('info', 'transcription', 'model ready')
 ioLog('error', 'transcription', 'warmup failed', { error: String(err) })
 
-// With Hono request context (sets trace_id automatically)
-logFromContext(c, 'info', 'nats', 'message published', { task_id: taskId, subject })
+// With Hono request context (sets trace_id and task_id automatically)
+logFromContext(c, 'info', 'nats', 'message published', { subject })
 ```
 
 ## Example Log Lines
 
 ```json
-{"time":"2026-04-17T10:00:00.000Z","level":"INFO","msg":"vault listening","service":"vault","component":"server","addr":":8000"}
-{"time":"2026-04-17T10:00:01.123Z","level":"INFO","msg":"streams ready","service":"databus","component":"server","startup_s":1.123}
-{"time":"2026-04-17T10:00:02.456Z","level":"WARN","msg":"compaction failed, continuing","service":"agents","component":"agent-process","task_id":"abc","trace_id":"def","error":"context deadline exceeded"}
-{"time":"2026-04-17T10:00:03.789Z","level":"ERROR","msg":"database ping failed","service":"memory","component":"server","error":"connection refused"}
-{"time":"2026-04-17T10:00:04.000Z","level":"INFO","msg":"task dispatched","service":"orchestrator","component":"dispatcher","trace_id":"xyz","task_id":"123"}
-{"time":"2026-04-17T10:00:05.111Z","level":"ERROR","msg":"config load failed","service":"io-api","component":"server","exit_code":1,"error":"missing NATS_URL"}
+{"time":"2026-04-17T10:00:00.000Z","level":"INFO","msg":"vault listening","component":"vault","module":"server","addr":":8000"}
+{"time":"2026-04-17T10:00:01.123Z","level":"INFO","msg":"streams ready","component":"databus","module":"server","startup_s":1.123}
+{"time":"2026-04-17T10:00:02.456Z","level":"WARN","msg":"compaction failed, continuing","component":"agents","module":"agent-process","task_id":"abc","trace_id":"def","error":"context deadline exceeded"}
+{"time":"2026-04-17T10:00:03.789Z","level":"ERROR","msg":"database ping failed","component":"memory","module":"server","error":"connection refused"}
+{"time":"2026-04-17T10:00:04.000Z","level":"INFO","msg":"task dispatched","component":"orchestrator","module":"dispatcher","trace_id":"xyz","task_id":"123","conversation_id":"conv-abc"}
+{"time":"2026-04-17T10:00:05.111Z","level":"ERROR","msg":"config load failed","component":"io","module":"server","exit_code":1,"error":"missing NATS_URL"}
 ```

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,19 +1,32 @@
 # cerberOS Logging Standard
 
-All services emit **structured JSON logs**, one object per line, to stdout (stderr for `agents/agent-process` only — its stdout carries the JSON task output).
+All runtime components emit **structured JSON logs**, one object per line, using
+the same schema. Logs go to stdout except for `agents-component/cmd/agent-process`,
+which writes logs to stderr because stdout carries the JSON task protocol.
 
-## Canonical Fields
+## Canonical Schema
+
+Every log line uses this field order:
+
+1. Required base fields: `time`, `level`, `msg`, `service`, `component`
+2. Correlation fields: `task_id`, `trace_id`, `request_id`, `message_id` when applicable
+3. Safe component-specific fields
 
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
-| `time` | string | ✅ | RFC3339Nano — e.g. `2026-04-17T10:00:00.000Z` |
-| `level` | string | ✅ | `DEBUG` `INFO` `WARN` `ERROR` |
-| `msg` | string | ✅ | Short imperative sentence; no trailing period |
-| `service` | string | ✅ | Fixed per binary — see table below |
-| `component` | string | ✅ | Sub-package or logical unit within the service |
-| `trace_id` | string | ○ | W3C 32-hex trace ID; omit when not in a traced request |
+| `time` | string | yes | RFC3339Nano or ISO-8601 UTC timestamp |
+| `level` | string | yes | `DEBUG` `INFO` `WARN` `ERROR` |
+| `msg` | string | yes | Short event name or sentence; no trailing period |
+| `service` | string | yes | Fixed per binary; see table below |
+| `component` | string | yes | Sub-package or logical unit within the service |
+| `task_id` | string | task logs | Required while handling or routing a task |
+| `trace_id` | string | traced logs | W3C 32-hex trace ID; required when available in context |
+| `request_id` | string | request logs | Vault execute, HTTP, NATS, or component request ID |
+| `message_id` | string | message logs | NATS/envelope message ID when available |
 
-Additional key-value pairs append after `component`.
+Additional key-value pairs append after the canonical fields. They must be safe
+metadata, never raw payloads, raw user input, credentials, permission tokens, or
+operation results.
 
 ## Service Names
 
@@ -26,6 +39,9 @@ Additional key-value pairs append after `component`.
 | `memory` | `memory` |
 | `orchestrator` | `orchestrator` |
 | `io/api` | `io-api` |
+| `io/core` | `io-core` |
+| `io/surfaces/web` | `io-web` |
+| `io/surfaces/cli` | `io-cli` |
 
 ## Level Semantics
 
@@ -36,7 +52,63 @@ Additional key-value pairs append after `component`.
 | `WARN` | Degraded but continuing; no operator action required |
 | `ERROR` | Operation failed; service continues |
 
-**There is no `FATAL` or `CRITICAL` level.** For unrecoverable errors, log at `ERROR` then call `os.Exit(1)`. `CRITICAL` maps to `ERROR`. `WARNING` maps to `WARN`.
+Only `DEBUG`, `INFO`, `WARN`, and `ERROR` are emitted. This matches Go
+`log/slog` and keeps the format portable across Go and TypeScript components.
+
+Unrecoverable failures are logged at `ERROR` with safe context such as
+`exit_code`, `reason`, or `operation`, then the process exits.
+
+Input/migration aliases:
+
+| Input | Emitted |
+|-------|---------|
+| `FATAL` | `ERROR` |
+| `CRITICAL` | `ERROR` |
+| `WARNING` | `WARN` |
+
+## Coverage Requirements
+
+Each runtime component should log these lifecycle events in the canonical JSON
+format:
+
+- Startup/configuration loaded
+- External connection state (NATS, database, OpenBao, HTTP listener)
+- Ready/healthy state
+- Shutdown
+- Error paths
+
+Task-handling logs must include `task_id`. If trace context is available, include
+`trace_id` on the same log line.
+
+## Out of Scope
+
+The logging standard does not apply to:
+
+- Intentional CLI or demo stdout, such as `vault inject` output
+- Test-only loggers in `*_test.go`
+- Prometheus text endpoints
+- JSON HTTP response bodies
+- Vault audit records, which are a separate channel and record key names only
+
+## Loki and Grafana
+
+Promtail parses the canonical JSON fields before pushing logs to Loki. The
+bounded-cardinality fields `service`, `component`, and `level` are promoted to
+Loki labels so Grafana can filter component logs efficiently.
+
+High-cardinality correlation fields such as `task_id`, `trace_id`, `request_id`,
+and `message_id` remain in the JSON log body. Query them with LogQL JSON parsing:
+
+```logql
+{job="docker", service="orchestrator"} | json | task_id="task-123"
+```
+
+Use the bundled Grafana dashboard `CerberOS — container logs` to view all
+component logs:
+
+```logql
+{job="docker", service=~".+"}
+```
 
 ## Go Usage
 
@@ -49,11 +121,11 @@ logger := slog.New(slog.NewJSONHandler(os.Stdout, nil)).
 logger.Info("server started", "addr", ":8080")
 
 // Fatal (log + exit)
-logger.Error("config load failed", "error", err)
+logger.Error("config load failed", "error", err, "exit_code", 1)
 os.Exit(1)
 
-// With trace ID
-logger.Info("request received", "trace_id", traceID, "method", r.Method)
+// With task and trace IDs
+logger.Info("request received", "task_id", taskID, "trace_id", traceID, "method", r.Method)
 ```
 
 ## TypeScript Usage (io/* services)
@@ -66,7 +138,7 @@ ioLog('info', 'transcription', 'model ready')
 ioLog('error', 'transcription', 'warmup failed', { error: String(err) })
 
 // With Hono request context (sets trace_id automatically)
-logFromContext(c, 'info', 'nats', 'message published', { subject })
+logFromContext(c, 'info', 'nats', 'message published', { task_id: taskId, subject })
 ```
 
 ## Example Log Lines
@@ -77,5 +149,5 @@ logFromContext(c, 'info', 'nats', 'message published', { subject })
 {"time":"2026-04-17T10:00:02.456Z","level":"WARN","msg":"compaction failed, continuing","service":"agents","component":"agent-process","task_id":"abc","trace_id":"def","error":"context deadline exceeded"}
 {"time":"2026-04-17T10:00:03.789Z","level":"ERROR","msg":"database ping failed","service":"memory","component":"server","error":"connection refused"}
 {"time":"2026-04-17T10:00:04.000Z","level":"INFO","msg":"task dispatched","service":"orchestrator","component":"dispatcher","trace_id":"xyz","task_id":"123"}
-{"time":"2026-04-17T10:00:05.111Z","level":"INFO","msg":"model ready","service":"io-api","component":"transcription"}
+{"time":"2026-04-17T10:00:05.111Z","level":"ERROR","msg":"config load failed","service":"io-api","component":"server","exit_code":1,"error":"missing NATS_URL"}
 ```

--- a/io/api/src/index.ts
+++ b/io/api/src/index.ts
@@ -357,6 +357,8 @@ type AppEnv = {
   Variables: {
     traceId: string
     traceparent: string
+    taskId: string
+    conversationId: string
   }
 }
 
@@ -415,7 +417,8 @@ app.get('/api/tasks', (c) => {
 // Get status for a specific task
 app.get('/api/tasks/:taskId', (c) => {
   const taskId = c.req.param('taskId');
-  logFromContext(c, 'info', 'http', 'GET /api/tasks/:taskId', { task_id: taskId })
+  c.set('taskId', taskId)
+  logFromContext(c, 'info', 'http', 'GET /api/tasks/:taskId')
   const task = tasks.get(taskId);
   if (!task) {
     return c.json({ error: 'Task not found' }, 404);
@@ -461,11 +464,11 @@ app.post('/api/tasks', async (c) => {
   }
 
   const taskId = createdTask.taskId
+  c.set('taskId', taskId)
+  c.set('conversationId', createdTask.conversationId)
 
   logFromContext(c, 'info', 'http', 'POST /api/tasks', {
-    task_id: taskId,
     user_id: userId,
-    conversation_id: createdTask.conversationId,
   })
 
   const statusUpdate: StatusUpdate = {
@@ -501,9 +504,9 @@ app.post('/api/orchestrator/stream-events', async (c) => {
     return c.json({ error: 'invalid orchestrator stream event' }, 400);
   }
   const taskId = event.payload.taskId;
-  logFromContext(c, 'info', 'orchestrator', 'POST /api/orchestrator/stream-events', {
+  if (taskId) c.set('taskId', taskId)
+  logFromContext(c, 'info', 'orchestrator-proxy', 'POST /api/orchestrator/stream-events', {
     event_type: event.type,
-    task_id: taskId,
   })
   if (event.type === 'status') {
     tasks.set(taskId, event.payload);
@@ -548,8 +551,8 @@ app.post('/api/orchestrator/plan-decision', async (c) => {
     return c.json({ error: 'taskId and orchestratorTaskRef are required' }, 400)
   }
 
-  logFromContext(c, 'info', 'orchestrator', 'POST /api/orchestrator/plan-decision', {
-    task_id: taskId,
+  c.set('taskId', taskId)
+  logFromContext(c, 'info', 'orchestrator-proxy', 'POST /api/orchestrator/plan-decision', {
     orchestrator_task_ref: orchestratorTaskRef,
     approved,
   })
@@ -571,7 +574,6 @@ app.post('/api/orchestrator/plan-decision', async (c) => {
     })
   } catch (err) {
     logFromContext(c, 'error', 'nats', 'failed to publish plan_decision', {
-      task_id: taskId,
       err: String(err),
     })
     return c.json({ error: 'failed to publish decision' }, 502)
@@ -589,10 +591,10 @@ app.post('/api/chat', async (c) => {
   const body = (await c.req.json()) as SendMessageRequest;
   const { taskId, userId, content, conversationHistory, conversationId } = body as SendMessageRequest & { userId?: string };
   const effectiveUserId = userId || requestUserId(c)
+  if (taskId) c.set('taskId', taskId)
+  if (conversationId) c.set('conversationId', conversationId)
   logFromContext(c, 'info', 'http', 'POST /api/chat', {
-    task_id: taskId,
     user_id: effectiveUserId,
-    conversation_id: conversationId,
     content_len: content.length,
     history_len: conversationHistory?.length,
   })
@@ -649,15 +651,13 @@ app.post('/api/chat', async (c) => {
       })
       awaitingOrchestratorChat = true
       logFromContext(c, 'info', 'nats', 'published user_task', {
-        task_id: taskId,
         is_follow_up: isFollowUp,
-        has_conversation_id: !!conversationId,
         history_turns: conversationHistory?.length ?? 0,
         raw_input_len: rawInput.length,
       })
     } catch (err) {
       userTaskPublishError = String(err)
-      logFromContext(c, 'error', 'nats', 'failed to publish user_task', { task_id: taskId, err: userTaskPublishError })
+      logFromContext(c, 'error', 'nats', 'failed to publish user_task', { err: userTaskPublishError })
     }
   }
 
@@ -835,11 +835,13 @@ app.post('/api/chat', async (c) => {
 app.get('/api/logs/:taskId', async (c) => {
   const taskId = c.req.param('taskId');
   const userId = requestUserId(c)
-  logFromContext(c, 'info', 'http', 'GET /api/logs/:taskId', { task_id: taskId })
+  c.set('taskId', taskId)
+  logFromContext(c, 'info', 'http', 'GET /api/logs/:taskId')
   const task = await getTask(taskId, userId)
   if (!task) {
     return c.json({ logs: [] })
   }
+  c.set('conversationId', task.conversationId)
   const memoryLogs = await getConversationLogs(task.conversationId, { userId })
   const logs = memoryLogs.map(memoryToLogEntry)
   return c.json({ logs });
@@ -855,8 +857,8 @@ app.get('/api/conversations', async (c) => {
 app.get('/api/conversations/:conversationId/logs', async (c) => {
   const conversationId = c.req.param('conversationId')
   const userId = requestUserId(c)
+  c.set('conversationId', conversationId)
   logFromContext(c, 'info', 'http', 'GET /api/conversations/:conversationId/logs', {
-    conversation_id: conversationId,
     user_id: userId,
   })
   const memoryLogs = await getConversationLogs(conversationId, { userId })
@@ -884,8 +886,8 @@ app.post('/api/credential', async (c) => {
     value: string;
   };
   const { taskId, requestId, userId, keyName } = body;
+  c.set('taskId', taskId)
   logFromContext(c, 'info', 'http', 'POST /api/credential', {
-    task_id: taskId,
     request_id: requestId,
     user_id: userId,
     key_name: keyName,
@@ -952,7 +954,8 @@ app.post('/api/credential', async (c) => {
 
 app.get('/api/events/:taskId', (c) => {
   const taskId = c.req.param('taskId');
-  logFromContext(c, 'info', 'http', 'GET /api/events/:taskId', { task_id: taskId })
+  c.set('taskId', taskId)
+  logFromContext(c, 'info', 'http', 'GET /api/events/:taskId')
 
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {

--- a/io/api/src/index.ts
+++ b/io/api/src/index.ts
@@ -640,7 +640,7 @@ app.post('/api/chat', async (c) => {
       const isFollowUp = !conversationId && rawInput !== content
       await natsClient!.publishUserTask({
         task_id: taskId,
-        user_id: userId,
+        user_id: effectiveUserId,
         content,
         payload: { raw_input: rawInput },
         callback_topic: callbackTopicForTask(taskId),

--- a/io/api/src/logger.ts
+++ b/io/api/src/logger.ts
@@ -5,6 +5,7 @@
 import type { Context } from 'hono'
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+export type LogLevelInput = LogLevel | 'warning' | 'fatal' | 'critical'
 
 const SERVICE = 'io-api'
 
@@ -20,6 +21,8 @@ function normalizeLogLevel(raw: string | undefined): LogLevel {
   if (v === 'debug' || v === 'info' || v === 'warn' || v === 'error') {
     return v
   }
+  if (v === 'warning') return 'warn'
+  if (v === 'fatal' || v === 'critical') return 'error'
   return 'info'
 }
 
@@ -39,22 +42,23 @@ export type LogFields = Record<string, unknown>
  * Emit one structured log line (no request context).
  */
 export function ioLog(
-  level: LogLevel,
+  level: LogLevelInput,
   component: string,
   msg: string,
   fields: LogFields = {},
 ): void {
-  if (!shouldEmit(level)) return
+  const normalizedLevel = normalizeLogLevel(level)
+  if (!shouldEmit(normalizedLevel)) return
   const rec: Record<string, unknown> = {
     time: new Date().toISOString(),
-    level: level.toUpperCase(),
+    level: normalizedLevel.toUpperCase(),
     service: SERVICE,
     component,
     msg,
     ...fields,
   }
   const line = JSON.stringify(rec)
-  if (level === 'error') console.error(line)
+  if (normalizedLevel === 'error') console.error(line)
   else console.log(line)
 }
 
@@ -63,18 +67,19 @@ export function ioLog(
  */
 export function logFromContext(
   c: Context,
-  level: LogLevel,
+  level: LogLevelInput,
   component: string,
   msg: string,
   fields: LogFields = {},
 ): void {
   const traceId = c.get('traceId') as string | undefined
-  logFromContextWithTrace(traceId, level, component, msg, fields)
+  const taskId = c.get('taskId') as string | undefined
+  logFromContextWithTrace(traceId, level, component, msg, taskId ? { task_id: taskId, ...fields } : fields)
 }
 
 export function logFromContextWithTrace(
   traceId: string | undefined,
-  level: LogLevel,
+  level: LogLevelInput,
   component: string,
   msg: string,
   fields: LogFields = {},

--- a/io/api/src/logger.ts
+++ b/io/api/src/logger.ts
@@ -1,5 +1,12 @@
 /**
  * Structured JSON logs for centralized log systems (one JSON object per line).
+ *
+ * Canonical schema (see docs/logging.md):
+ *   { time, level, msg, component, module, ... }
+ *
+ * `component` is always the constant "io" since this logger lives inside the
+ * io component. The second argument to ioLog/logFromContext is the *module*
+ * — the sub-unit within io (e.g. "http", "nats", "transcription").
  */
 
 import type { Context } from 'hono'
@@ -7,7 +14,7 @@ import type { Context } from 'hono'
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
 export type LogLevelInput = LogLevel | 'warning' | 'fatal' | 'critical'
 
-const SERVICE = 'io-api'
+const COMPONENT = 'io'
 
 const levelRank: Record<LogLevel, number> = {
   debug: 0,
@@ -40,10 +47,15 @@ export type LogFields = Record<string, unknown>
 
 /**
  * Emit one structured log line (no request context).
+ *
+ * @param level   canonical level or alias (warning|fatal|critical)
+ * @param module  sub-unit name within the io component (e.g. "http", "nats")
+ * @param msg     short event name or sentence
+ * @param fields  additional safe metadata
  */
 export function ioLog(
   level: LogLevelInput,
-  component: string,
+  module: string,
   msg: string,
   fields: LogFields = {},
 ): void {
@@ -52,8 +64,8 @@ export function ioLog(
   const rec: Record<string, unknown> = {
     time: new Date().toISOString(),
     level: normalizedLevel.toUpperCase(),
-    service: SERVICE,
-    component,
+    component: COMPONENT,
+    module,
     msg,
     ...fields,
   }
@@ -63,27 +75,35 @@ export function ioLog(
 }
 
 /**
- * Structured log with trace_id from Hono context (set by trace middleware).
+ * Structured log with trace_id, task_id, and conversation_id pulled from Hono
+ * context. trace middleware sets traceId; route handlers set taskId and
+ * conversationId via c.set(...) at the top of each handler. Explicit fields
+ * passed in `fields` win over context values, so a route can override on a
+ * single line.
  */
 export function logFromContext(
   c: Context,
   level: LogLevelInput,
-  component: string,
+  module: string,
   msg: string,
   fields: LogFields = {},
 ): void {
   const traceId = c.get('traceId') as string | undefined
   const taskId = c.get('taskId') as string | undefined
-  logFromContextWithTrace(traceId, level, component, msg, taskId ? { task_id: taskId, ...fields } : fields)
+  const conversationId = c.get('conversationId') as string | undefined
+  const merged: LogFields = { ...fields }
+  if (taskId !== undefined && merged.task_id === undefined) merged.task_id = taskId
+  if (conversationId !== undefined && merged.conversation_id === undefined) merged.conversation_id = conversationId
+  logFromContextWithTrace(traceId, level, module, msg, merged)
 }
 
 export function logFromContextWithTrace(
   traceId: string | undefined,
   level: LogLevelInput,
-  component: string,
+  module: string,
   msg: string,
   fields: LogFields = {},
 ): void {
   const merged = traceId ? { ...fields, trace_id: traceId } : { ...fields }
-  ioLog(level, component, msg, merged)
+  ioLog(level, module, msg, merged)
 }

--- a/io/api/src/trace-context.ts
+++ b/io/api/src/trace-context.ts
@@ -7,6 +7,7 @@
  */
 
 import type { MiddlewareHandler } from 'hono'
+import { ioLog } from './logger'
 
 const VERSION = '00'
 const FLAGS = '01'
@@ -108,7 +109,7 @@ const MAX_BUFFER = 64
 let otlpReady = false
 
 if (OTLP_ENDPOINT) {
-  console.log(`[trace] OTLP exporter enabled → ${OTLP_ENDPOINT}/v1/traces`)
+  ioLog('info', 'trace', 'OTLP exporter enabled', { endpoint: `${OTLP_ENDPOINT}/v1/traces` })
 }
 
 function scheduleFlush() {
@@ -151,13 +152,16 @@ function flushSpans() {
   }).then(res => {
     if (!otlpReady && res.ok) {
       otlpReady = true
-      console.log(`[trace] OTLP export OK (${spans.length} spans → Tempo)`)
+      ioLog('info', 'trace', 'OTLP export OK', { spans: spans.length })
     }
     if (!res.ok) {
-      res.text().then(t => console.error(`[trace] OTLP export failed: ${res.status} ${t}`))
+      res.text().then(t => ioLog('error', 'trace', 'OTLP export failed', {
+        status: res.status,
+        response_bytes: t.length,
+      }))
     }
   }).catch(err => {
-    console.error(`[trace] OTLP export error: ${err}`)
+    ioLog('error', 'trace', 'OTLP export error', { error: String(err) })
   })
 }
 

--- a/io/api/src/trace-context.ts
+++ b/io/api/src/trace-context.ts
@@ -88,7 +88,9 @@ export function resolveTraceparent(incoming: string | undefined): {
 // ── OTLP HTTP span export (fire-and-forget to Tempo) ──────────────────────────
 
 const OTLP_ENDPOINT = process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? ''
-const SERVICE_NAME = process.env.OTEL_SERVICE_NAME ?? 'io-api'
+// `service.name` matches the canonical component name from docs/logging.md so
+// Tempo trace UI and Loki log labels stay aligned.
+const SERVICE_NAME = process.env.OTEL_SERVICE_NAME ?? 'io'
 
 interface OtlpSpan {
   traceId: string

--- a/io/core/src/memory-client.ts
+++ b/io/core/src/memory-client.ts
@@ -7,6 +7,22 @@ const MEMORY_API_KEY = process.env.MEMORY_API_KEY ?? ''
 
 const DEMO_MODE = !MEMORY_API_BASE
 
+type CoreLogLevel = 'debug' | 'info' | 'warn' | 'error'
+
+function memoryClientLog(level: CoreLogLevel, msg: string, fields: Record<string, unknown> = {}): void {
+  const rec = {
+    time: new Date().toISOString(),
+    level: level.toUpperCase(),
+    service: 'io-core',
+    component: 'memory-client',
+    msg,
+    ...fields,
+  }
+  const line = JSON.stringify(rec)
+  if (level === 'error') console.error(line)
+  else console.log(line)
+}
+
 interface DemoLogEntry {
   messageId: string
   conversationId: string
@@ -127,13 +143,14 @@ export async function createConversation(params: CreateConversationParams): Prom
       body: JSON.stringify(params),
     })
     if (!res.ok) {
-      console.error('[MemoryClient] Failed to create conversation:', res.status, await res.text())
+      const text = await res.text()
+      memoryClientLog('error', 'create conversation failed', { status: res.status, response_bytes: text.length })
       return null
     }
     const json = await res.json() as { data: { conversation: MemoryConversation } }
     return json.data?.conversation ?? null
   } catch (err) {
-    console.error('[MemoryClient] Network error creating conversation:', err)
+    memoryClientLog('error', 'create conversation network error', { error: String(err) })
     return null
   }
 }
@@ -174,13 +191,14 @@ export async function createTask(params: CreateTaskParams): Promise<MemoryTask |
       body: JSON.stringify(params),
     })
     if (!res.ok) {
-      console.error('[MemoryClient] Failed to create task:', res.status, await res.text())
+      const text = await res.text()
+      memoryClientLog('error', 'create task failed', { task_id: params.taskId, status: res.status, response_bytes: text.length })
       return null
     }
     const json = await res.json() as { data: { task: MemoryTask } }
     return json.data?.task ?? null
   } catch (err) {
-    console.error('[MemoryClient] Network error creating task:', err)
+    memoryClientLog('error', 'create task network error', { task_id: params.taskId, error: String(err) })
     return null
   }
 }
@@ -199,13 +217,13 @@ export async function getTask(taskId: string, userId: string): Promise<MemoryTas
       headers: { 'X-Internal-API-Key': MEMORY_API_KEY },
     })
     if (!res.ok) {
-      console.error('[MemoryClient] Failed to fetch task:', res.status)
+      memoryClientLog('error', 'fetch task failed', { task_id: taskId, status: res.status })
       return null
     }
     const json = await res.json() as { data: { task: MemoryTask } }
     return json.data?.task ?? null
   } catch (err) {
-    console.error('[MemoryClient] Network error fetching task:', err)
+    memoryClientLog('error', 'fetch task network error', { task_id: taskId, error: String(err) })
     return null
   }
 }
@@ -263,7 +281,8 @@ export async function appendLogEntry(params: AppendLogParams): Promise<MemoryLog
     })
 
     if (!res.ok) {
-      console.error('[MemoryClient] Failed to append log:', res.status, await res.text())
+      const text = await res.text()
+      memoryClientLog('error', 'append log failed', { task_id: params.taskId, status: res.status, response_bytes: text.length })
       return null
     }
 
@@ -274,7 +293,7 @@ export async function appendLogEntry(params: AppendLogParams): Promise<MemoryLog
     }
     return entry
   } catch (err) {
-    console.error('[MemoryClient] Network error appending log:', err)
+    memoryClientLog('error', 'append log network error', { task_id: params.taskId, error: String(err) })
     return null
   }
 }
@@ -309,7 +328,7 @@ export async function getConversationLogs(
     })
 
     if (!res.ok) {
-      console.error('[MemoryClient] Failed to fetch logs:', res.status)
+      memoryClientLog('error', 'fetch logs failed', { task_id: options?.taskId, status: res.status })
       return []
     }
 
@@ -321,7 +340,7 @@ export async function getConversationLogs(
     }
     return messages
   } catch (err) {
-    console.error('[MemoryClient] Network error fetching logs:', err)
+    memoryClientLog('error', 'fetch logs network error', { task_id: options?.taskId, error: String(err) })
     return []
   }
 }
@@ -350,13 +369,13 @@ export async function listConversations(
       },
     })
     if (!res.ok) {
-      console.error('[MemoryClient] Failed to list conversations:', res.status)
+      memoryClientLog('error', 'list conversations failed', { status: res.status })
       return []
     }
     const json = await res.json() as { data: { conversations: MemoryConversation[] } }
     return json.data?.conversations ?? []
   } catch (err) {
-    console.error('[MemoryClient] Network error listing conversations:', err)
+    memoryClientLog('error', 'list conversations network error', { error: String(err) })
     return []
   }
 }

--- a/io/core/src/memory-client.ts
+++ b/io/core/src/memory-client.ts
@@ -13,8 +13,8 @@ function memoryClientLog(level: CoreLogLevel, msg: string, fields: Record<string
   const rec = {
     time: new Date().toISOString(),
     level: level.toUpperCase(),
-    service: 'io-core',
-    component: 'memory-client',
+    component: 'io',
+    module: 'memory-client',
     msg,
     ...fields,
   }

--- a/io/surfaces/cli/src/cli.ts
+++ b/io/surfaces/cli/src/cli.ts
@@ -21,6 +21,14 @@ async function main() {
 }
 
 main().catch(err => {
-  console.error('Fatal error:', err)
+  console.error(JSON.stringify({
+    time: new Date().toISOString(),
+    level: 'ERROR',
+    service: 'io-cli',
+    component: 'cli',
+    msg: 'fatal error',
+    error: String(err),
+    exit_code: 1,
+  }))
   process.exit(1)
 })

--- a/io/surfaces/cli/src/cli.ts
+++ b/io/surfaces/cli/src/cli.ts
@@ -24,8 +24,8 @@ main().catch(err => {
   console.error(JSON.stringify({
     time: new Date().toISOString(),
     level: 'ERROR',
-    service: 'io-cli',
-    component: 'cli',
+    component: 'io',
+    module: 'cli',
     msg: 'fatal error',
     error: String(err),
     exit_code: 1,

--- a/io/surfaces/cli/src/session/store.ts
+++ b/io/surfaces/cli/src/session/store.ts
@@ -11,8 +11,8 @@ function sessionLog(msg: string, fields: Record<string, unknown> = {}): void {
   console.error(JSON.stringify({
     time: new Date().toISOString(),
     level: 'ERROR',
-    service: 'io-cli',
-    component: 'session-store',
+    component: 'io',
+    module: 'cli-session-store',
     msg,
     ...fields,
   }))

--- a/io/surfaces/cli/src/session/store.ts
+++ b/io/surfaces/cli/src/session/store.ts
@@ -7,6 +7,17 @@ import { readFile, writeFile, mkdir } from 'fs/promises'
 import { dirname } from 'path'
 import type { Task, StatusUpdate } from '@cerberos/io-core'
 
+function sessionLog(msg: string, fields: Record<string, unknown> = {}): void {
+  console.error(JSON.stringify({
+    time: new Date().toISOString(),
+    level: 'ERROR',
+    service: 'io-cli',
+    component: 'session-store',
+    msg,
+    ...fields,
+  }))
+}
+
 export interface StoredSession {
   version: number
   surfaceId: string
@@ -69,7 +80,7 @@ export class SessionStore {
     } else {
       this.tasks.unshift(task as Task)
     }
-    this.save().catch(console.error) // fire-and-forget
+    this.save().catch(err => sessionLog('session save failed', { task_id: task.id, error: String(err) })) // fire-and-forget
   }
 
   updateTaskStatus(update: StatusUpdate): void {
@@ -79,14 +90,14 @@ export class SessionStore {
     task.status = update.status
     task.lastUpdate = update.lastUpdate
     task.expectedNextInput = formatExpectedNextInput(update.expectedNextInputMinutes)
-    this.save().catch(console.error)
+    this.save().catch(err => sessionLog('session save failed', { task_id: update.taskId, error: String(err) }))
   }
 
   addMessage(taskId: string, role: 'user' | 'assistant', content: string): void {
     const history = this.conversationHistory.get(taskId) ?? []
     history.push({ role, content })
     this.conversationHistory.set(taskId, history)
-    this.save().catch(console.error)
+    this.save().catch(err => sessionLog('session save failed', { task_id: taskId, error: String(err) }))
   }
 
   getConversationHistory(taskId: string): Array<{ role: 'user' | 'assistant'; content: string }> {
@@ -95,7 +106,7 @@ export class SessionStore {
 
   setActiveTask(taskId: string): void {
     this.lastActiveTaskId = taskId
-    this.save().catch(console.error)
+    this.save().catch(err => sessionLog('session save failed', { task_id: taskId, error: String(err) }))
   }
 
   getActiveTaskId(): string | undefined {

--- a/io/surfaces/cli/src/surface-adapter.ts
+++ b/io/surfaces/cli/src/surface-adapter.ts
@@ -18,6 +18,19 @@ import { streamChat, fetchTasks } from './io/orchestrator-client'
 import { submitCredential } from './io/memory-client'
 import { SessionStore } from './session/store'
 
+function cliLog(level: 'info' | 'warn' | 'error', msg: string, fields: Record<string, unknown> = {}): void {
+  const line = JSON.stringify({
+    time: new Date().toISOString(),
+    level: level.toUpperCase(),
+    service: 'io-cli',
+    component: 'surface-adapter',
+    msg,
+    ...fields,
+  })
+  if (level === 'error') console.error(line)
+  else console.log(line)
+}
+
 export interface CLISurfaceConfig {
   surfaceId?: string
   apiUrl?: string
@@ -45,18 +58,17 @@ export class CLISurfaceAdapter implements SurfaceAdapter {
 
   async initialize(): Promise<void> {
     await this.store.load()
-    console.log(`[CLISurfaceAdapter] Initialized: ${this.surfaceId}`)
-    console.log(`[CLISurfaceAdapter] API URL: ${this.apiUrl}`)
+    cliLog('info', 'initialized', { surface_id: this.surfaceId, api_url: this.apiUrl })
   }
 
   receiveInput(input: ProcessedInput): void {
     if (input.type !== 'text') {
-      console.warn('[CLISurfaceAdapter] Non-text input not supported in CLI')
+      cliLog('warn', 'non-text input not supported', { input_type: input.type })
       return
     }
     // In library mode, this is a fire-and-forget send
     this.sendMessage(input.taskId ?? this.store.getActiveTaskId() ?? 'unknown', input.content)
-      .catch(console.error)
+      .catch(err => cliLog('error', 'send message failed', { task_id: input.taskId, error: String(err) }))
   }
 
   showTaskStatus(update: StatusUpdate): void {
@@ -91,7 +103,7 @@ export class CLISurfaceAdapter implements SurfaceAdapter {
   }
 
   async shutdown(): Promise<void> {
-    console.log(`[CLISurfaceAdapter] Shutdown: ${this.surfaceId}`)
+    cliLog('info', 'shutdown', { surface_id: this.surfaceId })
   }
 
   async sendMessage(taskId: string, content: string): Promise<string> {

--- a/io/surfaces/cli/src/surface-adapter.ts
+++ b/io/surfaces/cli/src/surface-adapter.ts
@@ -22,8 +22,8 @@ function cliLog(level: 'info' | 'warn' | 'error', msg: string, fields: Record<st
   const line = JSON.stringify({
     time: new Date().toISOString(),
     level: level.toUpperCase(),
-    service: 'io-cli',
-    component: 'surface-adapter',
+    component: 'io',
+    module: 'cli-surface-adapter',
     msg,
     ...fields,
   })

--- a/io/surfaces/web/src/App.tsx
+++ b/io/surfaces/web/src/App.tsx
@@ -593,15 +593,13 @@ function App() {
     // Keep tasks in sync
     const unsubscribe = surface.onStatusUpdate((update) => {
       // When status updates come in, we could update tasks here
-      // For now, just log
-      console.log('[App] Surface status update:', update.taskId, update.status)
+      void update
     })
 
     // Expose the adapter globally for orchestrator integration
     // @ts-expect-error - Adding to window for external access
     window.__cerberosSurface = surface
 
-    console.log('[App] SurfaceAdapter initialized')
     return () => {
       unsubscribe()
       surface.shutdown()

--- a/io/surfaces/web/src/api/orchestrator.ts
+++ b/io/surfaces/web/src/api/orchestrator.ts
@@ -167,7 +167,6 @@ export async function submitCredential(
     return { ok: true, keyName: params.keyName }
   } catch (err) {
     // In demo mode the endpoint won't exist — simulate success
-    console.log('[credential] Demo mode: simulating credential storage')
     return { ok: true, keyName: params.keyName }
   }
 }

--- a/io/surfaces/web/src/lib/logging.ts
+++ b/io/surfaces/web/src/lib/logging.ts
@@ -40,7 +40,6 @@ function isoNow(): string {
 export function logUserResponse(taskId: string, content: string): void {
   const entry: LogEntry = { taskId, role: 'user', content, at: isoNow() }
   memoryLog.push(entry)
-  console.log('[LOG user]', taskId, content)
 }
 
 /**
@@ -49,7 +48,6 @@ export function logUserResponse(taskId: string, content: string): void {
 export function logOrchestratorResponse(taskId: string, content: string): void {
   const entry: LogEntry = { taskId, role: 'orchestrator', content, at: isoNow() }
   memoryLog.push(entry)
-  console.log('[LOG orchestrator]', taskId, content)
 }
 
 /**

--- a/io/surfaces/web/src/surface/SurfaceFactory.ts
+++ b/io/surfaces/web/src/surface/SurfaceFactory.ts
@@ -26,6 +26,17 @@ import type { SurfaceAdapter, SurfaceCapabilities } from '@cerberos/io-core'
 // Import built-in web implementation
 import { createWebSurface, type WebSurfaceConfig } from './WebSurfaceAdapter'
 
+function factoryLog(msg: string, fields: Record<string, unknown> = {}): void {
+  console.log(JSON.stringify({
+    time: new Date().toISOString(),
+    level: 'INFO',
+    service: 'io-web',
+    component: 'surface-factory',
+    msg,
+    ...fields,
+  }))
+}
+
 // ============================================================================
 // Extensible Type Map
 // ============================================================================
@@ -80,7 +91,7 @@ export function registerSurface<TType extends SurfaceType>(
 export function registerSurface(type: string, creator: SurfaceCreator<string>): void
 export function registerSurface(type: string, creator: SurfaceCreator<string>): void {
   surfaceRegistry.set(type.toLowerCase(), creator)
-  console.log(`[SurfaceFactory] Registered surface type: ${type}`)
+  factoryLog('surface registered', { surface_type: type })
 }
 
 /** Check if a surface type is registered */
@@ -123,7 +134,7 @@ export async function createSurface(config: SurfaceConfig<string>): Promise<Surf
     )
   }
 
-  console.log(`[SurfaceFactory] Creating surface: ${type}`)
+  factoryLog('surface creating', { surface_type: type })
   return creator(config)
 }
 
@@ -183,7 +194,7 @@ export function mergeCapabilities(surfaces: SurfaceAdapter[]): SurfaceCapabiliti
 function initializeBuiltins(): void {
   registerSurface('web', (config) => createWebSurface(config.config as WebSurfaceConfig | undefined))
 
-  console.log('[SurfaceFactory] Initialized with surfaces:', getRegisteredSurfaces().join(', '))
+  factoryLog('surface factory initialized', { surfaces: getRegisteredSurfaces() })
 }
 
 // Auto-initialize built-ins on import

--- a/io/surfaces/web/src/surface/SurfaceFactory.ts
+++ b/io/surfaces/web/src/surface/SurfaceFactory.ts
@@ -30,8 +30,8 @@ function factoryLog(msg: string, fields: Record<string, unknown> = {}): void {
   console.log(JSON.stringify({
     time: new Date().toISOString(),
     level: 'INFO',
-    service: 'io-web',
-    component: 'surface-factory',
+    component: 'io',
+    module: 'web-surface-factory',
     msg,
     ...fields,
   }))

--- a/io/surfaces/web/src/surface/WebSurfaceAdapter.ts
+++ b/io/surfaces/web/src/surface/WebSurfaceAdapter.ts
@@ -21,6 +21,19 @@ import type {
   ChatMessage,
 } from '@cerberos/io-core'
 
+function webLog(level: 'info' | 'warn' | 'error', component: string, msg: string, fields: Record<string, unknown> = {}): void {
+  const line = JSON.stringify({
+    time: new Date().toISOString(),
+    level: level.toUpperCase(),
+    service: 'io-web',
+    component,
+    msg,
+    ...fields,
+  })
+  if (level === 'error') console.error(line)
+  else console.log(line)
+}
+
 /** Configuration for creating a web surface adapter */
 export interface WebSurfaceConfig {
   /** Unique identifier for this surface instance */
@@ -93,56 +106,54 @@ export class WebSurfaceAdapter implements SurfaceAdapter {
   }
 
   async initialize(): Promise<void> {
-    console.log(`[WebSurfaceAdapter] Initialized: ${this.surfaceId}`)
+    webLog('info', 'surface-adapter', 'initialized', { surface_id: this.surfaceId })
     // The React app handles its own initialization
     // This is a no-op for the adapter
   }
 
   receiveInput(input: ProcessedInput): void {
-    console.log(`[WebSurfaceAdapter] Received input:`, input)
-
     if (input.type === 'text' && input.content.trim()) {
       const taskId = input.taskId ?? this.tasks[0]?.id
 
       if (taskId && this.taskCallbacks.onSendMessage) {
         this.taskCallbacks.onSendMessage(taskId, input.content.trim())
       } else {
-        console.warn('[WebSurfaceAdapter] No task selected and no default available')
+        webLog('warn', 'surface-adapter', 'no task selected', { input_type: input.type })
       }
     }
   }
 
   showTaskStatus(update: StatusUpdate): void {
-    console.log(`[WebSurfaceAdapter] Status update:`, update)
-
     // Notify all registered status callbacks
     this.statusCallbacks.forEach(cb => {
       try {
         cb(update)
       } catch (e) {
-        console.error('[WebSurfaceAdapter] Status callback error:', e)
+        webLog('error', 'surface-adapter', 'status callback error', {
+          task_id: update.taskId,
+          status: update.status,
+          error: String(e),
+        })
       }
     })
   }
 
   deliverResponse(response: AgentResponse): void {
-    console.log(`[WebSurfaceAdapter] Response:`, response)
-
     // Notify all registered response callbacks
     this.responseCallbacks.forEach(cb => {
       try {
         cb(response)
       } catch (e) {
-        console.error('[WebSurfaceAdapter] Response callback error:', e)
+        webLog('error', 'surface-adapter', 'response callback error', {
+          task_id: response.taskId,
+          error: String(e),
+        })
       }
     })
   }
 
   notify(notification: Notification): void {
-    console.log(`[WebSurfaceAdapter] Notification:`, notification)
-
     // For web, we could use the browser Notification API
-    // For now, just log it
     if (notification.priority === 'urgent' && 'Notification' in window) {
       if (Notification.permission === 'granted') {
         new Notification(notification.title, { body: notification.body })
@@ -166,7 +177,7 @@ export class WebSurfaceAdapter implements SurfaceAdapter {
   }
 
   async shutdown(): Promise<void> {
-    console.log(`[WebSurfaceAdapter] Shutting down: ${this.surfaceId}`)
+    webLog('info', 'surface-adapter', 'shutting down', { surface_id: this.surfaceId })
     this.statusCallbacks.clear()
     this.responseCallbacks.clear()
     this.taskCallbacks = {}
@@ -203,7 +214,7 @@ export function createWebSurface(config?: WebSurfaceConfig): WebSurfaceAdapter {
  */
 export function getSurfaceAdapter(): SurfaceAdapter {
   if (!webSurfaceAdapter) {
-    console.warn('[WebSurfaceAdapter] Not initialized - creating default instance')
+    webLog('warn', 'surface-adapter', 'not initialized, creating default instance')
     webSurfaceAdapter = createWebSurface()
   }
   return webSurfaceAdapter

--- a/io/surfaces/web/src/surface/WebSurfaceAdapter.ts
+++ b/io/surfaces/web/src/surface/WebSurfaceAdapter.ts
@@ -21,12 +21,12 @@ import type {
   ChatMessage,
 } from '@cerberos/io-core'
 
-function webLog(level: 'info' | 'warn' | 'error', component: string, msg: string, fields: Record<string, unknown> = {}): void {
+function webLog(level: 'info' | 'warn' | 'error', module: string, msg: string, fields: Record<string, unknown> = {}): void {
   const line = JSON.stringify({
     time: new Date().toISOString(),
     level: level.toUpperCase(),
-    service: 'io-web',
-    component,
+    component: 'io',
+    module: `web-${module}`,
     msg,
     ...fields,
   })

--- a/memory/cmd/server/main.go
+++ b/memory/cmd/server/main.go
@@ -73,7 +73,7 @@ func newHealthzHandler(db *storage.PostgresDB, logger *slog.Logger) http.Handler
 func main() {
 	// Initialize structured logging
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil)).
-		With("service", "memory", "component", "server")
+		With("component", "memory", "module", "server")
 	slog.SetDefault(logger)
 
 	// Load .env file if it exists

--- a/memory/internal/heartbeat/heartbeat.go
+++ b/memory/internal/heartbeat/heartbeat.go
@@ -70,7 +70,7 @@ func New(nc *nats.Conn, service string, log *slog.Logger) *Emitter {
 		hostname:   host,
 		pid:        pid,
 		subject:    SubjectPrefix + service,
-		log:        log.With("component", "heartbeat", "service", service),
+		log:        log.With("module", "heartbeat"),
 		interval:   DefaultInterval,
 		startedAt:  time.Now().UTC(),
 	}

--- a/orchestrator/cmd/orchestrator/main.go
+++ b/orchestrator/cmd/orchestrator/main.go
@@ -49,7 +49,7 @@ import (
 func main() {
 	cfg, err := loadRuntimeConfig()
 	if err != nil {
-		observability.LoggerWithComponent("main").
+		observability.LoggerWithModule("main").
 			Error("config load failed", "error", err, "exit_code", 1)
 		os.Exit(1)
 	}
@@ -260,7 +260,7 @@ func loadRuntimeConfig() (*config.OrchestratorConfig, error) {
 	cfg, err := config.Load()
 	if err != nil {
 		cfg = demoConfig()
-		observability.LoggerWithComponent("main").
+		observability.LoggerWithModule("main").
 			Warn("config incomplete, starting from demo defaults", "error", err)
 	}
 	applyEnvOverrides(cfg)

--- a/orchestrator/cmd/orchestrator/main.go
+++ b/orchestrator/cmd/orchestrator/main.go
@@ -17,7 +17,6 @@ package main
 
 import (
 	"context"
-	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -38,10 +37,10 @@ import (
 	ioclient "github.com/mlim3/cerberOS/orchestrator/internal/io"
 	memoryiface "github.com/mlim3/cerberOS/orchestrator/internal/memory"
 	"github.com/mlim3/cerberOS/orchestrator/internal/mocks"
-	"github.com/mlim3/cerberOS/orchestrator/internal/personalization"
 	"github.com/mlim3/cerberOS/orchestrator/internal/monitor"
 	natsclient "github.com/mlim3/cerberOS/orchestrator/internal/nats"
 	"github.com/mlim3/cerberOS/orchestrator/internal/observability"
+	"github.com/mlim3/cerberOS/orchestrator/internal/personalization"
 	"github.com/mlim3/cerberOS/orchestrator/internal/policy"
 	"github.com/mlim3/cerberOS/orchestrator/internal/recovery"
 	"github.com/mlim3/cerberOS/orchestrator/internal/types"
@@ -50,9 +49,8 @@ import (
 func main() {
 	cfg, err := loadRuntimeConfig()
 	if err != nil {
-		slog.New(slog.NewJSONHandler(os.Stdout, nil)).
-			With("service", "orchestrator", "component", "main").
-			Error("config load failed", "error", err)
+		observability.LoggerWithComponent("main").
+			Error("config load failed", "error", err, "exit_code", 1)
 		os.Exit(1)
 	}
 
@@ -124,20 +122,20 @@ func main() {
 }
 
 type runtime struct {
-	memory         *memoryiface.Interface
-	vault          *mocks.VaultMock
-	nats           interfaces.NATSClient
-	mockNATS       *mocks.NATSMock
-	mockMemory     *mocks.MemoryMock
-	gateway        *gateway.Gateway
-	monitor        *monitor.Monitor
-	recovery       *recovery.Manager
-	dispatcher     *dispatcher.Dispatcher
-	executor       *executor.PlanExecutor
-	health         *health.Handler
-	hbEmitter      *heartbeat.Emitter
-	hbSweeper      *heartbeat.Sweeper
-	mux            *http.ServeMux
+	memory     *memoryiface.Interface
+	vault      *mocks.VaultMock
+	nats       interfaces.NATSClient
+	mockNATS   *mocks.NATSMock
+	mockMemory *mocks.MemoryMock
+	gateway    *gateway.Gateway
+	monitor    *monitor.Monitor
+	recovery   *recovery.Manager
+	dispatcher *dispatcher.Dispatcher
+	executor   *executor.PlanExecutor
+	health     *health.Handler
+	hbEmitter  *heartbeat.Emitter
+	hbSweeper  *heartbeat.Sweeper
+	mux        *http.ServeMux
 }
 
 func buildRuntime(cfg *config.OrchestratorConfig) (*runtime, error) {
@@ -262,8 +260,7 @@ func loadRuntimeConfig() (*config.OrchestratorConfig, error) {
 	cfg, err := config.Load()
 	if err != nil {
 		cfg = demoConfig()
-		slog.New(slog.NewJSONHandler(os.Stdout, nil)).
-			With("service", "orchestrator", "component", "main").
+		observability.LoggerWithComponent("main").
 			Warn("config incomplete, starting from demo defaults", "error", err)
 	}
 	applyEnvOverrides(cfg)

--- a/orchestrator/internal/dispatcher/dispatcher.go
+++ b/orchestrator/internal/dispatcher/dispatcher.go
@@ -153,7 +153,7 @@ func New(
 		monitor:  monitor,
 		executor: executor,
 		io:       io,
-		logger:   slog.Default().With("module", "dispatcher"),
+		logger:   observability.LoggerWithComponent("dispatcher"),
 	}
 }
 

--- a/orchestrator/internal/dispatcher/dispatcher.go
+++ b/orchestrator/internal/dispatcher/dispatcher.go
@@ -153,7 +153,7 @@ func New(
 		monitor:  monitor,
 		executor: executor,
 		io:       io,
-		logger:   observability.LoggerWithComponent("dispatcher"),
+		logger:   observability.LoggerWithModule("dispatcher"),
 	}
 }
 
@@ -889,6 +889,7 @@ func ctxFromTaskState(ts *types.TaskState, module string) context.Context {
 		ctx = observability.WithTraceID(ctx, ts.TraceID)
 	}
 	ctx = observability.WithTaskID(ctx, ts.TaskID)
+	ctx = observability.WithConversationID(ctx, ts.ConversationID)
 	if ts.PlanID != "" {
 		ctx = observability.WithPlanID(ctx, ts.PlanID)
 	}

--- a/orchestrator/internal/executor/executor.go
+++ b/orchestrator/internal/executor/executor.go
@@ -427,6 +427,7 @@ func (e *PlanExecutor) checkPlanCompletion(exec *planExecution) {
 		planCtx = observability.WithTraceID(planCtx, exec.ts.TraceID)
 	}
 	planCtx = observability.WithTaskID(planCtx, exec.ts.TaskID)
+	planCtx = observability.WithConversationID(planCtx, exec.ts.ConversationID)
 	planCtx = observability.WithPlanID(planCtx, exec.plan.PlanID)
 	planCtx = observability.WithModule(planCtx, "plan_executor")
 	log := observability.LogFromContext(planCtx)

--- a/orchestrator/internal/gateway/gateway.go
+++ b/orchestrator/internal/gateway/gateway.go
@@ -236,6 +236,7 @@ func (g *Gateway) handleRawInboundTask(subject string, data []byte) error {
 
 	ctx := extractOrCreateCtx(envelope, "comms_gateway")
 	ctx = observability.WithTaskID(ctx, task.TaskID)
+	ctx = observability.WithConversationID(ctx, task.ConversationID)
 
 	ctx, span := observability.StartSpan(ctx, "task_received")
 	defer span.End()

--- a/orchestrator/internal/heartbeat/emitter.go
+++ b/orchestrator/internal/heartbeat/emitter.go
@@ -85,9 +85,11 @@ func NewEmitter(client interfaces.NATSClient, service string) *Emitter {
 
 // Start publishes beats until ctx is done.
 func (e *Emitter) Start(ctx context.Context) {
-	log := observability.LogFromContext(ctx).With(
-		"component", "heartbeat_emitter",
-		"service", e.service,
+	// The orchestrator binary owns this emitter, so component stays as
+	// "orchestrator". `peer_service` is the heartbeat subject's service token,
+	// which for the orchestrator's own beats equals "orchestrator".
+	log := observability.LogFromContext(observability.WithModule(ctx, "heartbeat_emitter")).With(
+		"peer_service", e.service,
 	)
 
 	ticker := time.NewTicker(e.interval)

--- a/orchestrator/internal/heartbeat/sweeper.go
+++ b/orchestrator/internal/heartbeat/sweeper.go
@@ -159,9 +159,11 @@ func (s *Sweeper) handleMessage(subject string, data []byte) error {
 	s.mu.Unlock()
 
 	if had && prev.stale {
-		observability.LogFromContext(context.Background()).Info(
+		observability.LogFromContext(
+			observability.WithModule(context.Background(), "heartbeat_sweeper"),
+		).Info(
 			"heartbeat: service recovered",
-			"service", beat.Service,
+			"peer_service", beat.Service,
 			"instance_id", beat.InstanceID,
 		)
 	}
@@ -202,7 +204,7 @@ func (s *Sweeper) sweep(log *slog.Logger) {
 
 	for _, sh := range newlyStale {
 		log.Warn("heartbeat: service stale",
-			"service", sh.Service,
+			"peer_service", sh.Service,
 			"instance_id", sh.InstanceID,
 			"last_seen", sh.LastSeen.Format(time.RFC3339),
 			"age_seconds", sh.AgeSeconds,

--- a/orchestrator/internal/heartbeat/sweeper.go
+++ b/orchestrator/internal/heartbeat/sweeper.go
@@ -114,7 +114,7 @@ func NewSweeper(client interfaces.NATSClient, opts ...Option) *Sweeper {
 // Returns an error if subscription fails; otherwise runs until ctx is
 // done.
 func (s *Sweeper) Start(ctx context.Context) error {
-	log := observability.LogFromContext(ctx).With("component", "heartbeat_sweeper")
+	log := observability.LogFromContext(observability.WithModule(ctx, "heartbeat_sweeper"))
 
 	if err := s.client.Subscribe(SubjectWildcard, s.handleMessage); err != nil {
 		return err
@@ -169,7 +169,7 @@ func (s *Sweeper) handleMessage(subject string, data []byte) error {
 }
 
 func (s *Sweeper) sweepLoop(ctx context.Context) {
-	log := observability.LogFromContext(ctx).With("component", "heartbeat_sweeper")
+	log := observability.LogFromContext(observability.WithModule(ctx, "heartbeat_sweeper"))
 	ticker := time.NewTicker(s.sweepInterval)
 	defer ticker.Stop()
 

--- a/orchestrator/internal/io/client.go
+++ b/orchestrator/internal/io/client.go
@@ -108,7 +108,7 @@ func New(baseURL string) *Client {
 		httpClient: &http.Client{
 			Timeout: 5 * time.Second,
 		},
-		logger: observability.LoggerWithComponent("io-client"),
+		logger: observability.LoggerWithModule("io-client"),
 	}
 }
 

--- a/orchestrator/internal/io/client.go
+++ b/orchestrator/internal/io/client.go
@@ -14,17 +14,18 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
-	"os"
 	"time"
+
+	"github.com/mlim3/cerberOS/orchestrator/internal/observability"
 )
 
 // TaskStatus values match the IO component's TaskStatus type.
 const (
-	StatusWorking         = "working"
+	StatusWorking          = "working"
 	StatusAwaitingFeedback = "awaiting_feedback"
-	StatusCompleted       = "completed"
+	StatusCompleted        = "completed"
 )
 
 // streamEventsPath is the IO endpoint that accepts orchestrator-pushed events.
@@ -38,18 +39,18 @@ type statusEvent struct {
 }
 
 type statusPayload struct {
-	TaskID                   string  `json:"taskId"`
-	Status                   string  `json:"status"`
-	LastUpdate               string  `json:"lastUpdate"`
-	ExpectedNextInputMinutes *int    `json:"expectedNextInputMinutes"`
-	Timestamp                int64   `json:"timestamp"` // Unix ms
+	TaskID                   string `json:"taskId"`
+	Status                   string `json:"status"`
+	LastUpdate               string `json:"lastUpdate"`
+	ExpectedNextInputMinutes *int   `json:"expectedNextInputMinutes"`
+	Timestamp                int64  `json:"timestamp"` // Unix ms
 }
 
 // credentialRequestEvent is the envelope for a credential request pushed to IO.
 // Matches: { type: 'credential_request', payload: CredentialRequest } in io/core/src/types.ts
 type credentialRequestEvent struct {
-	Type    string                    `json:"type"`
-	Payload CredentialRequestPayload  `json:"payload"`
+	Type    string                   `json:"type"`
+	Payload CredentialRequestPayload `json:"payload"`
 }
 
 // planPreviewEvent is the envelope for a plan preview pushed to IO.
@@ -96,7 +97,7 @@ type CredentialRequestPayload struct {
 type Client struct {
 	baseURL    string
 	httpClient *http.Client
-	logger     *log.Logger
+	logger     *slog.Logger
 }
 
 // New returns a new Client targeting baseURL (e.g. "http://localhost:3001").
@@ -107,7 +108,7 @@ func New(baseURL string) *Client {
 		httpClient: &http.Client{
 			Timeout: 5 * time.Second,
 		},
-		logger: log.New(os.Stdout, "[io-client] ", log.LstdFlags|log.LUTC),
+		logger: observability.LoggerWithComponent("io-client"),
 	}
 }
 
@@ -172,13 +173,26 @@ func (c *Client) post(body any) error {
 	resp, err := c.httpClient.Post(url, "application/json", bytes.NewReader(data))
 	if err != nil {
 		// IO may be down — log but do not return an error that would fail the task.
-		c.logger.Printf("POST %s failed (IO may be down): %v", url, err)
+		c.logger.Warn("IO post failed", "task_id", taskIDFromEvent(body), "url", url, "error", err)
 		return nil
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		c.logger.Printf("POST %s returned %d", url, resp.StatusCode)
+		c.logger.Warn("IO post returned non-OK", "task_id", taskIDFromEvent(body), "url", url, "status", resp.StatusCode)
 	}
 	return nil
+}
+
+func taskIDFromEvent(body any) string {
+	switch evt := body.(type) {
+	case statusEvent:
+		return evt.Payload.TaskID
+	case planPreviewEvent:
+		return evt.Payload.TaskID
+	case credentialRequestEvent:
+		return evt.Payload.TaskID
+	default:
+		return ""
+	}
 }

--- a/orchestrator/internal/monitor/monitor.go
+++ b/orchestrator/internal/monitor/monitor.go
@@ -46,6 +46,8 @@ func New(cfg *config.OrchestratorConfig, memory interfaces.MemoryClient, recover
 // Returns error if rehydration takes longer than 10 seconds (§NFR-06).
 func (m *Monitor) RehydrateFromMemory() error {
 	start := time.Now()
+	log := observability.LogFromContext(observability.WithModule(context.Background(), "task_monitor"))
+	log.Info("task monitor rehydration started")
 
 	records, err := m.memory.Read(types.MemoryQuery{
 		DataType: types.DataTypeTaskState,
@@ -77,6 +79,7 @@ func (m *Monitor) RehydrateFromMemory() error {
 	if time.Since(start) > 10*time.Second {
 		return fmt.Errorf("rehydration exceeded 10 second startup budget")
 	}
+	log.Info("task monitor rehydration complete", "tasks_restored", len(latestByTask), "elapsed_ms", time.Since(start).Milliseconds())
 	return nil
 }
 
@@ -87,6 +90,9 @@ func (m *Monitor) TrackTask(ts *types.TaskState) {
 		return
 	}
 	m.activeTasks.Store(ts.TaskID, ts)
+	observability.LogFromContext(taskCtx(ts, "task_monitor")).Info("task tracking started",
+		"state", ts.State,
+	)
 	go m.monitorTaskTimeout(ts)
 }
 
@@ -117,6 +123,7 @@ func (m *Monitor) StateTransition(_ context.Context, taskID, newState, reason st
 		return fmt.Errorf("invalid state transition: %s -> %s", ts.State, newState)
 	}
 
+	fromState := ts.State
 	now := time.Now().UTC()
 	ts.State = newState
 	if types.IsTerminalState(newState) {
@@ -159,6 +166,11 @@ func (m *Monitor) StateTransition(_ context.Context, taskID, newState, reason st
 	if types.IsTerminalState(newState) {
 		m.activeTasks.Delete(taskID)
 	}
+	observability.LogFromContext(taskCtx(ts, "task_monitor")).Info("task state transitioned",
+		"from_state", fromState,
+		"to_state", newState,
+		"reason", reason,
+	)
 	return nil
 }
 
@@ -236,9 +248,7 @@ func (m *Monitor) monitorTaskTimeout(ts *types.TaskState) {
 
 		remaining := time.Until(*current.TimeoutAt)
 		if remaining > 0 {
-			select {
-			case <-time.After(remaining):
-			}
+			time.Sleep(remaining)
 			continue
 		}
 
@@ -247,12 +257,14 @@ func (m *Monitor) monitorTaskTimeout(ts *types.TaskState) {
 		// for that phase. Re-check periodically so we still enforce the
 		// backstop once execution resumes.
 		if current.State == types.StateAwaitingApproval {
-			select {
-			case <-time.After(approvalRecheckInterval):
-			}
+			time.Sleep(approvalRecheckInterval)
 			continue
 		}
 
+		observability.LogFromContext(ctx).Warn("task timeout elapsed",
+			"state", current.State,
+			"timeout_at", current.TimeoutAt.Format(time.RFC3339Nano),
+		)
 		m.recovery.HandleRecovery(ctx, current, types.RecoveryReasonTimeout)
 		return
 	}

--- a/orchestrator/internal/monitor/monitor.go
+++ b/orchestrator/internal/monitor/monitor.go
@@ -278,6 +278,7 @@ func taskCtx(ts *types.TaskState, module string) context.Context {
 		ctx = observability.WithTraceID(ctx, ts.TraceID)
 	}
 	ctx = observability.WithTaskID(ctx, ts.TaskID)
+	ctx = observability.WithConversationID(ctx, ts.ConversationID)
 	ctx = observability.WithModule(ctx, module)
 	return ctx
 }

--- a/orchestrator/internal/observability/context.go
+++ b/orchestrator/internal/observability/context.go
@@ -16,11 +16,12 @@ import "context"
 type ctxKey int
 
 const (
-	traceIDKey   ctxKey = iota // trace_id — root correlation ID across all components
-	taskIDKey                  // task_id — user-facing task identifier
-	planIDKey                  // plan_id — execution plan identifier
-	subtaskIDKey               // subtask_id — individual subtask identifier
-	moduleKey                  // module — name of the module generating the log line
+	traceIDKey        ctxKey = iota // trace_id — root correlation ID across all components
+	taskIDKey                       // task_id — user-facing task identifier
+	conversationIDKey               // conversation_id — stable thread ID linking tasks in the same chat
+	planIDKey                       // plan_id — execution plan identifier
+	subtaskIDKey                    // subtask_id — individual subtask identifier
+	moduleKey                       // module — name of the module generating the log line
 )
 
 // WithTraceID returns a context carrying the given trace ID.
@@ -31,6 +32,16 @@ func WithTraceID(ctx context.Context, id string) context.Context {
 // WithTaskID returns a context carrying the given task ID.
 func WithTaskID(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, taskIDKey, id)
+}
+
+// WithConversationID returns a context carrying the given conversation ID.
+// Empty IDs are dropped so callers can pass through optional values without a
+// guard at every call site.
+func WithConversationID(ctx context.Context, id string) context.Context {
+	if id == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, conversationIDKey, id)
 }
 
 // WithPlanID returns a context carrying the given plan ID.
@@ -57,6 +68,12 @@ func TraceIDFrom(ctx context.Context) string {
 // TaskIDFrom extracts the task ID from the context, or "" if not set.
 func TaskIDFrom(ctx context.Context) string {
 	v, _ := ctx.Value(taskIDKey).(string)
+	return v
+}
+
+// ConversationIDFrom extracts the conversation ID from the context, or "" if not set.
+func ConversationIDFrom(ctx context.Context) string {
+	v, _ := ctx.Value(conversationIDKey).(string)
 	return v
 }
 

--- a/orchestrator/internal/observability/logger.go
+++ b/orchestrator/internal/observability/logger.go
@@ -46,26 +46,37 @@ func InitLogger(level, format, node string) {
 	defaultLogger = slog.New(slog.NewJSONHandler(os.Stdout, opts))
 }
 
-// LoggerWithComponent returns the default orchestrator logger with canonical
-// service/component attrs. Prefer LogFromContext when context IDs are available.
-func LoggerWithComponent(component string) *slog.Logger {
-	attrs := []any{"service", "orchestrator", "component", component}
+// LoggerWithModule returns the default orchestrator logger with the canonical
+// component=orchestrator attribute and the supplied module name. Prefer
+// LogFromContext when context IDs are available.
+func LoggerWithModule(module string) *slog.Logger {
+	attrs := []any{"component", "orchestrator", "module", module}
 	if nodeID != "" {
 		attrs = append(attrs, "node_id", nodeID)
 	}
 	return defaultLogger.With(attrs...)
 }
 
+// LoggerWithComponent is a deprecated alias for LoggerWithModule kept so older
+// call sites compile. Its argument is the module name within the orchestrator
+// component, despite the legacy name.
+//
+// Deprecated: use LoggerWithModule.
+func LoggerWithComponent(module string) *slog.Logger {
+	return LoggerWithModule(module)
+}
+
 // LogFromContext returns a *slog.Logger pre-populated with all IDs present in ctx.
 //
 // Required fields on every line (EDD §15.1):
-//   - component = "orchestrator"
-//   - node_id   (from InitLogger)
-//   - trace_id  (from context, if set)
-//   - task_id   (from context, if set)
-//   - plan_id   (from context, if set)
-//   - subtask_id (from context, if set)
-//   - module    (from context, if set)
+//   - component       = "orchestrator"
+//   - node_id         (from InitLogger)
+//   - trace_id        (from context, if set)
+//   - task_id         (from context, if set)
+//   - conversation_id (from context, if set)
+//   - plan_id         (from context, if set)
+//   - subtask_id      (from context, if set)
+//   - module          (from context, if set)
 //
 // FORBIDDEN log content (EDD §15.1):
 //   - raw user input (payload.raw_input)
@@ -80,6 +91,9 @@ func LogFromContext(ctx context.Context) *slog.Logger {
 	if v := TaskIDFrom(ctx); v != "" {
 		attrs = append(attrs, "task_id", v)
 	}
+	if v := ConversationIDFrom(ctx); v != "" {
+		attrs = append(attrs, "conversation_id", v)
+	}
 	if v := PlanIDFrom(ctx); v != "" {
 		attrs = append(attrs, "plan_id", v)
 	}
@@ -89,5 +103,12 @@ func LogFromContext(ctx context.Context) *slog.Logger {
 	if v := ModuleFrom(ctx); v != "" {
 		attrs = append(attrs, "module", v)
 	}
-	return LoggerWithComponent("orchestrator").With(attrs...)
+	// Note: when the context carries no module, we still emit component=orchestrator
+	// so every line has the canonical component label even if the caller has not
+	// chosen a module yet.
+	base := []any{"component", "orchestrator"}
+	if nodeID != "" {
+		base = append(base, "node_id", nodeID)
+	}
+	return defaultLogger.With(base...).With(attrs...)
 }

--- a/orchestrator/internal/observability/logger.go
+++ b/orchestrator/internal/observability/logger.go
@@ -23,34 +23,37 @@ func init() {
 // InitLogger sets up the global structured logger.
 // Must be called once from main.go before any log output.
 //
-//   - level:  "debug" | "info" | "warn" | "error"  (default: "info")
-//   - format: "json" (production) | "text" (local dev)
+//   - level:  "debug" | "info" | "warn" | "warning" | "error" | "fatal" | "critical" (default: "info")
+//   - format: accepted for backward compatibility; logs are always JSON
 //   - node:   NODE_ID value for the node_id field
 func InitLogger(level, format, node string) {
+	_ = format
 	nodeID = node
 
 	var lvl slog.Level
 	switch strings.ToLower(level) {
 	case "debug":
 		lvl = slog.LevelDebug
-	case "warn":
+	case "warn", "warning":
 		lvl = slog.LevelWarn
-	case "error":
+	case "error", "fatal", "critical":
 		lvl = slog.LevelError
 	default:
 		lvl = slog.LevelInfo
 	}
 
 	opts := &slog.HandlerOptions{Level: lvl}
+	defaultLogger = slog.New(slog.NewJSONHandler(os.Stdout, opts))
+}
 
-	var handler slog.Handler
-	if strings.ToLower(format) == "text" {
-		handler = slog.NewTextHandler(os.Stdout, opts)
-	} else {
-		handler = slog.NewJSONHandler(os.Stdout, opts)
+// LoggerWithComponent returns the default orchestrator logger with canonical
+// service/component attrs. Prefer LogFromContext when context IDs are available.
+func LoggerWithComponent(component string) *slog.Logger {
+	attrs := []any{"service", "orchestrator", "component", component}
+	if nodeID != "" {
+		attrs = append(attrs, "node_id", nodeID)
 	}
-
-	defaultLogger = slog.New(handler)
+	return defaultLogger.With(attrs...)
 }
 
 // LogFromContext returns a *slog.Logger pre-populated with all IDs present in ctx.
@@ -70,13 +73,7 @@ func InitLogger(level, format, node string) {
 //   - task result payloads
 //   - planner output
 func LogFromContext(ctx context.Context) *slog.Logger {
-	attrs := []any{
-		"service", "orchestrator",
-		"component", "orchestrator",
-	}
-	if nodeID != "" {
-		attrs = append(attrs, "node_id", nodeID)
-	}
+	attrs := []any{}
 	if v := TraceIDFrom(ctx); v != "" {
 		attrs = append(attrs, "trace_id", v)
 	}
@@ -92,5 +89,5 @@ func LogFromContext(ctx context.Context) *slog.Logger {
 	if v := ModuleFrom(ctx); v != "" {
 		attrs = append(attrs, "module", v)
 	}
-	return defaultLogger.With(attrs...)
+	return LoggerWithComponent("orchestrator").With(attrs...)
 }

--- a/orchestrator/internal/obslog/obslog.go
+++ b/orchestrator/internal/obslog/obslog.go
@@ -7,11 +7,14 @@ import (
 	"github.com/mlim3/cerberOS/orchestrator/internal/observability"
 )
 
-const Service = "orchestrator"
+// Component is the canonical component name for orchestrator logs.
+// Sub-units within the orchestrator are emitted as the `module` field.
+const Component = "orchestrator"
 
-// NewLogger returns a slog JSON logger with service + component attributes.
-func NewLogger(component string) *slog.Logger {
-	return observability.LoggerWithComponent(component)
+// NewLogger returns a slog JSON logger with the canonical component attribute
+// and the supplied module name.
+func NewLogger(module string) *slog.Logger {
+	return observability.LoggerWithModule(module)
 }
 
 // AppendTrace appends trace_id when non-empty (W3C 32-hex from I/O).

--- a/orchestrator/internal/obslog/obslog.go
+++ b/orchestrator/internal/obslog/obslog.go
@@ -3,15 +3,15 @@ package obslog
 
 import (
 	"log/slog"
-	"os"
+
+	"github.com/mlim3/cerberOS/orchestrator/internal/observability"
 )
 
 const Service = "orchestrator"
 
 // NewLogger returns a slog JSON logger with service + component attributes.
 func NewLogger(component string) *slog.Logger {
-	h := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})
-	return slog.New(h).With("service", Service, "component", component)
+	return observability.LoggerWithComponent(component)
 }
 
 // AppendTrace appends trace_id when non-empty (W3C 32-hex from I/O).

--- a/orchestrator/internal/recovery/manager.go
+++ b/orchestrator/internal/recovery/manager.go
@@ -144,9 +144,10 @@ func (m *Manager) HandleRecovery(ctx context.Context, ts *types.TaskState, reaso
 // HandleComponentFailure is called by Memory Interface when all write retries are exhausted.
 // Terminates the affected task if it can be identified (§4.1 M5).
 func (m *Manager) HandleComponentFailure(ctx context.Context, payload types.OrchestratorMemoryWritePayload, writeErr error) {
-	observability.LogFromContext(ctx).Error("CRITICAL: memory write failed after all retries",
+	observability.LogFromContext(ctx).Error("memory write failed after all retries",
 		"task_id", payload.TaskID,
 		"orchestrator_task_ref", payload.OrchestratorTaskRef,
+		"severity", "critical",
 		"error", writeErr,
 	)
 	// Best-effort: attempt credential revocation even without a full TaskState.

--- a/orchestrator/observability/grafana/dashboards/cerberos-logs.json
+++ b/orchestrator/observability/grafana/dashboards/cerberos-logs.json
@@ -25,7 +25,7 @@
         {
           "datasource": { "type": "loki", "uid": "loki" },
           "editorMode": "code",
-          "expr": "{job=\"docker\", service=~\".+\"}",
+          "expr": "{job=\"docker\", component=~\".+\"}",
           "queryType": "range",
           "refId": "A"
         }

--- a/orchestrator/observability/grafana/dashboards/cerberos-logs.json
+++ b/orchestrator/observability/grafana/dashboards/cerberos-logs.json
@@ -25,12 +25,12 @@
         {
           "datasource": { "type": "loki", "uid": "loki" },
           "editorMode": "code",
-          "expr": "{compose_service=~\"orchestrator|io|nats\"}",
+          "expr": "{job=\"docker\", service=~\".+\"}",
           "queryType": "range",
           "refId": "A"
         }
       ],
-      "title": "IO + Orchestrator + NATS (JSON parse)",
+      "title": "cerberOS component JSON logs",
       "type": "logs"
     }
   ],

--- a/orchestrator/observability/promtail/config.yml
+++ b/orchestrator/observability/promtail/config.yml
@@ -50,13 +50,19 @@ scrape_configs:
         target_label: container_name
 
     # Unwrap Docker json-file log lines ({"log":"...","stream":"stdout",...}) into plain text for Loki,
-    # then parse the standardized cerberOS JSON log schema.
+    # then parse the standardized cerberOS JSON log schema (see docs/logging.md).
+    #
+    # `component` is one of the six top-level components (agents, orchestrator,
+    # io, memory, vault, databus). `module` is the sub-unit within a component
+    # (server, dispatcher, http, ...). Both are bounded enough to be Loki labels.
+    # task_id / trace_id stay in the log body for LogQL `| json` queries and
+    # Tempo links.
     pipeline_stages:
       - docker: {}
       - json:
           expressions:
-            service: service
             component: component
+            module: module
             level: level
             msg: msg
             task_id: task_id
@@ -64,6 +70,6 @@ scrape_configs:
             request_id: request_id
             message_id: message_id
       - labels:
-          service:
           component:
+          module:
           level:

--- a/orchestrator/observability/promtail/config.yml
+++ b/orchestrator/observability/promtail/config.yml
@@ -1,6 +1,7 @@
 # Promtail: ship Docker container logs → Loki.
 # Expects compose-managed containers (label com.docker.compose.service).
-# JSON fields (service, trace_id, component) stay in the log line — query with Grafana: | json
+# App JSON fields are parsed into Loki labels where cardinality is bounded.
+# task_id / trace_id stay in the log line for LogQL `| json` queries and Tempo links.
 
 server:
   http_listen_port: 9080
@@ -48,6 +49,21 @@ scrape_configs:
         regex: /(.*)
         target_label: container_name
 
-    # Unwrap Docker json-file log lines ({"log":"...","stream":"stdout",...}) into plain text for Loki.
+    # Unwrap Docker json-file log lines ({"log":"...","stream":"stdout",...}) into plain text for Loki,
+    # then parse the standardized cerberOS JSON log schema.
     pipeline_stages:
       - docker: {}
+      - json:
+          expressions:
+            service: service
+            component: component
+            level: level
+            msg: msg
+            task_id: task_id
+            trace_id: trace_id
+            request_id: request_id
+            message_id: message_id
+      - labels:
+          service:
+          component:
+          level:

--- a/vault/engine/heartbeat/heartbeat.go
+++ b/vault/engine/heartbeat/heartbeat.go
@@ -70,7 +70,7 @@ func New(nc *nats.Conn, service string, log *slog.Logger) *Emitter {
 		hostname:   host,
 		pid:        pid,
 		subject:    SubjectPrefix + service,
-		log:        log.With("component", "heartbeat", "service", service),
+		log:        log.With("module", "heartbeat"),
 		interval:   DefaultInterval,
 		startedAt:  time.Now().UTC(),
 	}

--- a/vault/engine/main.go
+++ b/vault/engine/main.go
@@ -43,7 +43,7 @@ func main() {
 	defer cancel()
 
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil)).
-		With("service", "vault", "component", "server")
+		With("component", "vault", "module", "server")
 
 	// Heartbeat emitter — non-fatal if NATS is unavailable.
 	if natsURL := os.Getenv("NATS_URL"); natsURL != "" {


### PR DESCRIPTION
This obviously touches a lot of files across all or most components. I tested it end-to-end with parallel and sequential multi-step prompting.

Ideally, one of each of the databus and orchestrator components could test this PR end to end before approving or commenting.

One thing to note is that what's called 'Task' in the UI Dashboard visible to the user, is called 
**'conversation'** and gets a conversation_id
in the logs. Each message in that conversation is called 
**'task'** and gets a task_id.
Some components don't have those but they have the
**trace_id** which belongs to one task_id which in turn belongs to one conversation_id.

If the team thinks it would be better to ensure that every log always has all three (conversation_id, task_id, and trace_id) I could make that change but it would be even deeper. So, I decided to put that off until it's clear that it's necessary.