### PR TITLE
feat(io): animated plan execution pipeline (#151)

### DIFF
--- a/io/core/src/types.ts
+++ b/io/core/src/types.ts
@@ -146,6 +146,16 @@ export interface PlanPreview {
 
 export type PlanDecisionStatus = 'pending' | 'submitting' | 'approved' | 'rejected' | 'error';
 
+export type PlanStepStatus = 'completed' | 'active' | 'upcoming';
+
+export interface PlanStep {
+  id: string;
+  label: string;
+  description?: string;
+  status: PlanStepStatus;
+  output?: string;
+}
+
 /** IO → Orchestrator: user's decision on a plan preview. */
 export interface PlanDecisionSubmission {
   taskId: string;

--- a/io/surfaces/web/src/App.tsx
+++ b/io/surfaces/web/src/App.tsx
@@ -7,11 +7,13 @@ import type {
   OrchestratorStreamEvent,
   PlanPreview,
   PlanDecisionStatus,
+  PlanStep,
 } from '@cerberos/io-core'
 import TaskSidebar from './components/TaskSidebar'
 import ChatWindow from './components/ChatWindow'
 import CredentialModal from './components/CredentialModal'
 import PlanPreviewCard from './components/PlanPreviewCard'
+import PlanPipeline from './components/PlanPipeline'
 import SettingsButton from './components/SettingsButton'
 import SettingsPanel, { defaultUISettings } from './components/SettingsPanel'
 import type { UISettings } from './components/SettingsPanel'
@@ -296,6 +298,11 @@ function App() {
     Record<string, { preview: PlanPreview; status: PlanDecisionStatus; error?: string }>
   >({})
 
+  // Plan execution pipeline state — tracks step progression after approval.
+  const [planExecution, setPlanExecution] = useState<
+    Record<string, { steps: PlanStep[]; currentStepIndex: number }>
+  >({})
+
   const selectedTask = tasks.find(t => t.id === selectedTaskId)
 
   const addLogEntry = useCallback((entry: Omit<LogEntry, 'id' | 'timestamp'>) => {
@@ -462,6 +469,22 @@ function App() {
       }
     })
   }, [DEMO_MODE, useMockHeartbeat, selectedTaskId])
+
+  // Demo mode: show a mock plan execution pipeline for task 4 (API endpoint testing)
+  useEffect(() => {
+    if (!DEMO_MODE) return
+    setPlanExecution({
+      '4': {
+        steps: [
+          { id: 's1', label: 'Fetch schema diff', status: 'completed', output: '3 tables, 12 columns changed' },
+          { id: 's2', label: 'Validate migration', status: 'completed', output: 'All constraints satisfied' },
+          { id: 's3', label: 'Run integration tests', status: 'active', description: 'Running test suite...' },
+          { id: 's4', label: 'Generate coverage report', status: 'upcoming' },
+        ],
+        currentStepIndex: 2,
+      },
+    })
+  }, [])
 
   // Refs to hold callbacks for SurfaceAdapter integration
   const tasksRef = useRef(tasks)
@@ -1025,6 +1048,14 @@ function App() {
                 onApprove={() => selectedTask.currentTaskId && handlePlanDecision(selectedTask.currentTaskId, true)}
                 onReject={reason => selectedTask.currentTaskId && handlePlanDecision(selectedTask.currentTaskId, false, reason)}
               />
+            )}
+            {planExecution[selectedTask.id] && (
+              <div style={{ padding: '0 40px' }}>
+                <PlanPipeline
+                  steps={planExecution[selectedTask.id].steps}
+                  currentStepIndex={planExecution[selectedTask.id].currentStepIndex}
+                />
+              </div>
             )}
             <ChatWindow
               task={selectedTask}

--- a/io/surfaces/web/src/components/PlanPipeline.css
+++ b/io/surfaces/web/src/components/PlanPipeline.css
@@ -1,0 +1,205 @@
+.plan-pipeline {
+  display: flex;
+  flex-direction: column;
+  padding: var(--sp-3) 0;
+}
+
+.pipeline-step {
+  display: flex;
+  gap: var(--sp-3);
+  transition: opacity 0.4s ease-out, transform 0.4s ease-out;
+}
+
+.pipeline-step-completed {
+  opacity: 0.4;
+  transform: scale(0.97);
+  transform-origin: left center;
+}
+
+.pipeline-step-active {
+  opacity: 1;
+  transform: scale(1);
+  padding: var(--sp-3);
+  background: rgba(100, 149, 237, 0.06);
+  border-radius: 8px;
+  border: 1px solid rgba(100, 149, 237, 0.1);
+  margin: var(--sp-1) 0;
+}
+
+.pipeline-step-next {
+  opacity: 0.4;
+}
+
+.pipeline-step-future {
+  opacity: 0.15;
+}
+
+.pipeline-rail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex-shrink: 0;
+  width: 22px;
+}
+
+.pipeline-circle {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.pipeline-circle-completed {
+  background: rgba(126, 231, 135, 0.15);
+}
+
+.pipeline-circle-active {
+  background: rgba(100, 149, 237, 0.2);
+  box-shadow: 0 0 8px rgba(100, 149, 237, 0.2);
+}
+
+.pipeline-circle-next,
+.pipeline-circle-future {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.pipeline-check {
+  color: var(--success);
+  font-size: 10px;
+}
+
+.pipeline-active-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.pipeline-number {
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.pipeline-line {
+  width: 1px;
+  flex: 1;
+  min-height: 16px;
+}
+
+.pipeline-line-completed {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.pipeline-line-active {
+  background: rgba(100, 149, 237, 0.2);
+}
+
+.pipeline-line-next,
+.pipeline-line-future {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.pipeline-content {
+  flex: 1;
+  min-width: 0;
+  padding: 2px 0 var(--sp-3);
+}
+
+.pipeline-label {
+  font-size: 11px;
+  color: var(--text-primary);
+}
+
+.pipeline-step-completed .pipeline-label {
+  font-size: 10px;
+  color: var(--text-secondary);
+}
+
+.pipeline-step-active .pipeline-label {
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.pipeline-step-next .pipeline-label,
+.pipeline-step-future .pipeline-label {
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
+.pipeline-label.clickable {
+  cursor: pointer;
+}
+
+.pipeline-label.clickable:hover {
+  color: var(--text-primary);
+}
+
+.pipeline-active-status {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: var(--sp-1);
+}
+
+.pipeline-status-dot {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: pipelinePulse 2s ease-in-out infinite;
+}
+
+.pipeline-status-text {
+  font-size: 9px;
+  color: var(--accent);
+}
+
+.pipeline-output {
+  margin-top: var(--sp-2);
+  padding: var(--sp-2) var(--sp-3);
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 4px;
+  font-size: 10px;
+  color: var(--text-secondary);
+  font-family: 'SF Mono', 'Fira Code', monospace;
+}
+
+.pipeline-single {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: var(--sp-1) 0;
+}
+
+.pipeline-single-dot {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: pipelinePulse 2s ease-in-out infinite;
+}
+
+.pipeline-single-text {
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
+@keyframes pipelinePulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pipeline-step {
+    transition: opacity 0.1s;
+    transform: none !important;
+  }
+  .pipeline-status-dot,
+  .pipeline-single-dot,
+  .pipeline-active-dot {
+    animation: none;
+  }
+}

--- a/io/surfaces/web/src/components/PlanPipeline.tsx
+++ b/io/surfaces/web/src/components/PlanPipeline.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react'
+import type { PlanStep } from '@cerberos/io-core'
+import './PlanPipeline.css'
+
+interface PlanPipelineProps {
+  steps: PlanStep[]
+  currentStepIndex: number
+}
+
+export default function PlanPipeline({ steps, currentStepIndex }: PlanPipelineProps) {
+  const [expandedStep, setExpandedStep] = useState<string | null>(null)
+
+  if (steps.length <= 1) {
+    const step = steps[0]
+    if (!step) return null
+    return (
+      <div className="pipeline-single">
+        <span className="pipeline-single-dot"></span>
+        <span className="pipeline-single-text">{step.label}</span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="plan-pipeline" role="list" aria-label="Plan execution progress">
+      {steps.map((step, i) => {
+        const zone = i < currentStepIndex ? 'completed'
+          : i === currentStepIndex ? 'active'
+          : i === currentStepIndex + 1 ? 'next'
+          : 'future'
+        const isExpanded = expandedStep === step.id
+        const isClickable = zone === 'completed' && !!step.output
+        const isLast = i === steps.length - 1
+
+        return (
+          <div
+            key={step.id}
+            className={`pipeline-step pipeline-step-${zone}`}
+            role="listitem"
+            aria-current={zone === 'active' ? 'step' : undefined}
+          >
+            <div className="pipeline-rail">
+              <div className={`pipeline-circle pipeline-circle-${zone}`}>
+                {zone === 'completed' ? (
+                  <span className="pipeline-check">{'\u2713'}</span>
+                ) : zone === 'active' ? (
+                  <span className="pipeline-active-dot"></span>
+                ) : (
+                  <span className="pipeline-number">{i + 1}</span>
+                )}
+              </div>
+              {!isLast && (
+                <div className={`pipeline-line pipeline-line-${zone}`}></div>
+              )}
+            </div>
+            <div className="pipeline-content">
+              <div
+                className={`pipeline-label ${isClickable ? 'clickable' : ''}`}
+                onClick={() => isClickable && setExpandedStep(isExpanded ? null : step.id)}
+                role={isClickable ? 'button' : undefined}
+                tabIndex={isClickable ? 0 : undefined}
+                onKeyDown={(e) => {
+                  if (isClickable && (e.key === 'Enter' || e.key === ' ')) {
+                    e.preventDefault()
+                    setExpandedStep(isExpanded ? null : step.id)
+                  }
+                }}
+              >
+                {step.label}
+              </div>
+              {zone === 'active' && step.description && (
+                <div className="pipeline-active-status">
+                  <span className="pipeline-status-dot"></span>
+                  <span className="pipeline-status-text">{step.description}</span>
+                </div>
+              )}
+              {isExpanded && step.output && (
+                <div className="pipeline-output">{step.output}</div>
+              )}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Vertical depth-stage pipeline for plan execution visualization
- Completed steps fade/shrink back, active step glows, upcoming steps ghosted
- CSS-only transitions (transforms + opacity, no layout thrashing)
- Click completed steps to expand output (dark inset panel)
- Single-step plans degrade gracefully (no pipeline chrome)
- `prefers-reduced-motion` respected — disables blur/scale, uses opacity only
- Mock pipeline data on task 4 (API endpoint testing) in demo mode

Closes #151

## Test plan
- [ ] Run dev server, select task 4 "API endpoint testing" in demo mode
- [ ] Verify pipeline renders with 2 completed, 1 active, 1 upcoming step
- [ ] Click completed steps — output expands
- [ ] Verify active step shows pulsing dot + status text
- [ ] Check `prefers-reduced-motion` in browser dev tools
- [ ] Keyboard: Tab to clickable steps, Enter/Space to expand

🤖 Generated with [Claude Code](https://claude.com/claude-code)