### PR TITLE
fix(agents): default ANTHROPIC_BASE_URL to api.anthropic.com

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -359,7 +359,7 @@ services:
       AEGIS_NATS_URL: nats://nats:4222
       AEGIS_AGENT_PROCESS_PATH: /app/agent-process
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-      ANTHROPIC_BASE_URL: ${ANTHROPIC_BASE_URL:-}
+      ANTHROPIC_BASE_URL: ${ANTHROPIC_BASE_URL:-https://api.anthropic.com}
       # Concurrency cap for inbound task dispatch. Without parallel workers,
       # JetStream delivers task.inbound serially and each HandleTaskSpec
       # (Firecracker provision) blocks subsequent tasks — two back-to-back


### PR DESCRIPTION
## Summary
- `ANTHROPIC_BASE_URL: ${ANTHROPIC_BASE_URL:-}` was passing an empty string to the container when the var isn't set in `.env`
- The Anthropic Go SDK treats an empty `ANTHROPIC_BASE_URL` as the base URL, producing `POST "/v1/messages"` with no scheme → **"unsupported protocol scheme \"\""**
- Fix: default to `https://api.anthropic.com` so the SDK gets a valid URL when `ANTHROPIC_BASE_URL` is absent

## Test plan
- [ ] `docker compose up aegis-agents` without `ANTHROPIC_BASE_URL` in `.env` — agent should call `api.anthropic.com` successfully
- [ ] With `ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic` in `.env` — override still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)