### PR TITLE
feat(deploy): auto-inject Anthropic env vars and add help menus to deploy scripts

### DIFF
--- a/deploy/helm/cerberos/values-dev.yaml
+++ b/deploy/helm/cerberos/values-dev.yaml
@@ -2,12 +2,10 @@
 # values-dev.yaml — kind local cluster overrides
 # =============================================================================
 # Usage:
-#   helm upgrade --install cerberos deploy/helm/cerberos \
-#     --namespace cerberos \
-#     -f deploy/helm/cerberos/values-dev.yaml \
-#     --set aegis-agents.anthropicApiKey=$ANTHROPIC_API_KEY \
-#     --set memory-api.vaultMasterKey=$VAULT_MASTER_KEY \
-#     --set memory-api.internalVaultApiKey=$INTERNAL_VAULT_API_KEY
+#   ./deploy/scripts/kind-up.sh
+#
+#   ANTHROPIC_API_KEY and ANTHROPIC_BASE_URL are read automatically from the
+#   environment by kind-up.sh — no --set flags needed.
 # =============================================================================
 
 # Use locally-built images (loaded via kind load docker-image)

--- a/deploy/helm/charts/aegis-agents/templates/deployment.yaml
+++ b/deploy/helm/charts/aegis-agents/templates/deployment.yaml
@@ -66,6 +66,10 @@ spec:
                   name: aegis-agents-secrets
                   key: ANTHROPIC_API_KEY
             {{- end }}
+            {{- if .Values.anthropicBaseUrl }}
+            - name: ANTHROPIC_BASE_URL
+              value: {{ .Values.anthropicBaseUrl | quote }}
+            {{- end }}
           {{- if .Values.firecracker.enabled }}
           securityContext:
             privileged: true

--- a/deploy/helm/charts/aegis-agents/values.yaml
+++ b/deploy/helm/charts/aegis-agents/values.yaml
@@ -15,6 +15,7 @@ natsUrl: "nats://nats:4222"
 agentProcessPath: "/app/agent-process"
 
 anthropicApiKey: ""
+anthropicBaseUrl: ""
 
 maxConcurrentTasks: "8"
 idleSuspendTimeout: "10m"

--- a/deploy/scripts/build-and-load.sh
+++ b/deploy/scripts/build-and-load.sh
@@ -4,6 +4,27 @@
 # Usage: ./deploy/scripts/build-and-load.sh [cluster-name]
 set -euo pipefail
 
+for arg in "$@"; do
+  case $arg in
+    -h|--help)
+      echo "Usage: ./deploy/scripts/build-and-load.sh [CLUSTER_NAME]"
+      echo ""
+      echo "Build all service Docker images and load them into a kind cluster."
+      echo ""
+      echo "Arguments:"
+      echo "  CLUSTER_NAME  Name of the kind cluster to load images into (default: cerberos)"
+      echo ""
+      echo "Options:"
+      echo "  -h, --help  Show this help message"
+      echo ""
+      echo "Examples:"
+      echo "  ./deploy/scripts/build-and-load.sh            # load into 'cerberos' cluster"
+      echo "  ./deploy/scripts/build-and-load.sh my-cluster # load into 'my-cluster'"
+      exit 0
+      ;;
+  esac
+done
+
 CLUSTER="${1:-cerberos}"
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 TAG="local"

--- a/deploy/scripts/kind-down.sh
+++ b/deploy/scripts/kind-down.sh
@@ -5,6 +5,20 @@ set -euo pipefail
 
 CLUSTER="cerberos"
 
+for arg in "$@"; do
+  case $arg in
+    -h|--help)
+      echo "Usage: ./deploy/scripts/kind-down.sh"
+      echo ""
+      echo "Tear down the '${CLUSTER}' kind cluster entirely."
+      echo ""
+      echo "Options:"
+      echo "  -h, --help  Show this help message"
+      exit 0
+      ;;
+  esac
+done
+
 echo "==> Deleting kind cluster '${CLUSTER}' ..."
 kind delete cluster --name "${CLUSTER}"
 echo "Done."

--- a/deploy/scripts/kind-up.sh
+++ b/deploy/scripts/kind-up.sh
@@ -58,9 +58,20 @@ if [ "$SKIP_INSTALL" = false ]; then
     fi
   done
   helm dependency update "${REPO_ROOT}/deploy/helm/cerberos" >/dev/null
+  HELM_SET_ARGS=()
+  if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+    HELM_SET_ARGS+=(--set "aegis-agents.anthropicApiKey=${ANTHROPIC_API_KEY}")
+  else
+    echo "    (warning: ANTHROPIC_API_KEY not set — aegis-agents will start without it)"
+  fi
+  if [ -n "${ANTHROPIC_BASE_URL:-}" ]; then
+    HELM_SET_ARGS+=(--set "aegis-agents.anthropicBaseUrl=${ANTHROPIC_BASE_URL}")
+  fi
+
   helm upgrade --install cerberos "${REPO_ROOT}/deploy/helm/cerberos" \
     --namespace "${NAMESPACE}" \
-    --values "${REPO_ROOT}/deploy/helm/cerberos/values-dev.yaml"
+    --values "${REPO_ROOT}/deploy/helm/cerberos/values-dev.yaml" \
+    "${HELM_SET_ARGS[@]}"
 
   echo ""
   echo "    Waiting for core workloads to be ready (up to 5 min) ..."

--- a/deploy/scripts/kind-up.sh
+++ b/deploy/scripts/kind-up.sh
@@ -14,6 +14,26 @@ for arg in "$@"; do
   case $arg in
     --skip-build) SKIP_BUILD=true ;;
     --skip-install) SKIP_INSTALL=true ;;
+    -h|--help)
+      echo "Usage: ./deploy/scripts/kind-up.sh [OPTIONS]"
+      echo ""
+      echo "Create the kind cluster, build & load images, and install the cerberOS Helm chart."
+      echo ""
+      echo "Options:"
+      echo "  --skip-build    Skip Docker image builds (use already-loaded images)"
+      echo "  --skip-install  Skip Helm chart install/upgrade"
+      echo "  -h, --help      Show this help message"
+      echo ""
+      echo "Environment variables (auto-injected into aegis-agents if set):"
+      echo "  ANTHROPIC_API_KEY   Anthropic API key"
+      echo "  ANTHROPIC_BASE_URL  Anthropic API base URL (defaults to Anthropic's standard endpoint)"
+      echo ""
+      echo "Examples:"
+      echo "  ./deploy/scripts/kind-up.sh                   # full setup"
+      echo "  ./deploy/scripts/kind-up.sh --skip-build      # reinstall chart without rebuilding images"
+      echo "  ./deploy/scripts/kind-up.sh --skip-install    # rebuild & reload images only"
+      exit 0
+      ;;
   esac
 done
 

--- a/deploy/scripts/kind-up.sh
+++ b/deploy/scripts/kind-up.sh
@@ -59,25 +59,12 @@ if [ "$SKIP_INSTALL" = false ]; then
   done
   helm dependency update "${REPO_ROOT}/deploy/helm/cerberos" >/dev/null
   HELM_SET_ARGS=()
-  echo ""
-  echo "    Anthropic configuration:"
   if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
-    echo "      ANTHROPIC_API_KEY  ✓ set (injecting into aegis-agents)"
     HELM_SET_ARGS+=(--set "aegis-agents.anthropicApiKey=${ANTHROPIC_API_KEY}")
-  else
-    echo "      ANTHROPIC_API_KEY  ✗ not set — aegis-agents will start without it"
-    echo "        If cluster already up:  kubectl set env deployment/aegis-agents ANTHROPIC_API_KEY=<key> -n ${NAMESPACE}"
-    echo "        If starting fresh:      export ANTHROPIC_API_KEY=<key>  then re-run with --skip-build"
   fi
   if [ -n "${ANTHROPIC_BASE_URL:-}" ]; then
-    echo "      ANTHROPIC_BASE_URL ✓ set (injecting into aegis-agents): ${ANTHROPIC_BASE_URL}"
     HELM_SET_ARGS+=(--set "aegis-agents.anthropicBaseUrl=${ANTHROPIC_BASE_URL}")
-  else
-    echo "      ANTHROPIC_BASE_URL ✗ not set — using Anthropic default endpoint"
-    echo "        If cluster already up:  kubectl set env deployment/aegis-agents ANTHROPIC_BASE_URL=<url> -n ${NAMESPACE}"
-    echo "        If starting fresh:      export ANTHROPIC_BASE_URL=<url>  then re-run with --skip-build"
   fi
-  echo ""
 
   helm upgrade --install cerberos "${REPO_ROOT}/deploy/helm/cerberos" \
     --namespace "${NAMESPACE}" \
@@ -117,4 +104,20 @@ echo "                  root token: root"
 echo ""
 echo "  All pods:       kubectl get pods -n ${NAMESPACE} -o wide"
 echo "  Tear down:      ./deploy/scripts/kind-down.sh"
+echo ""
+echo "  Anthropic (aegis-agents):"
+if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+  echo "    ANTHROPIC_API_KEY  ✓ injected"
+else
+  echo "    ANTHROPIC_API_KEY  ✗ not set"
+  echo "      Live cluster:  kubectl set env deployment/aegis-agents ANTHROPIC_API_KEY=<key> -n ${NAMESPACE}"
+  echo "      Fresh start:   export ANTHROPIC_API_KEY=<key> && ./deploy/scripts/kind-up.sh --skip-build"
+fi
+if [ -n "${ANTHROPIC_BASE_URL:-}" ]; then
+  echo "    ANTHROPIC_BASE_URL ✓ injected: ${ANTHROPIC_BASE_URL}"
+else
+  echo "    ANTHROPIC_BASE_URL ✗ not set (using Anthropic default endpoint)"
+  echo "      Live cluster:  kubectl set env deployment/aegis-agents ANTHROPIC_BASE_URL=<url> -n ${NAMESPACE}"
+  echo "      Fresh start:   export ANTHROPIC_BASE_URL=<url> && ./deploy/scripts/kind-up.sh --skip-build"
+fi
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/deploy/scripts/kind-up.sh
+++ b/deploy/scripts/kind-up.sh
@@ -66,14 +66,16 @@ if [ "$SKIP_INSTALL" = false ]; then
     HELM_SET_ARGS+=(--set "aegis-agents.anthropicApiKey=${ANTHROPIC_API_KEY}")
   else
     echo "      ANTHROPIC_API_KEY  ✗ not set — aegis-agents will start without it"
-    echo "        To inject: export ANTHROPIC_API_KEY=<your-key> then re-run this script"
+    echo "        If cluster already up:  kubectl set env deployment/aegis-agents ANTHROPIC_API_KEY=<key> -n ${NAMESPACE}"
+    echo "        If starting fresh:      export ANTHROPIC_API_KEY=<key>  then re-run with --skip-build"
   fi
   if [ -n "${ANTHROPIC_BASE_URL:-}" ]; then
     echo "      ANTHROPIC_BASE_URL ✓ set (injecting into aegis-agents): ${ANTHROPIC_BASE_URL}"
     HELM_SET_ARGS+=(--set "aegis-agents.anthropicBaseUrl=${ANTHROPIC_BASE_URL}")
   else
     echo "      ANTHROPIC_BASE_URL ✗ not set — using Anthropic default endpoint"
-    echo "        To inject: export ANTHROPIC_BASE_URL=<your-url> then re-run this script"
+    echo "        If cluster already up:  kubectl set env deployment/aegis-agents ANTHROPIC_BASE_URL=<url> -n ${NAMESPACE}"
+    echo "        If starting fresh:      export ANTHROPIC_BASE_URL=<url>  then re-run with --skip-build"
   fi
   echo ""
 

--- a/deploy/scripts/kind-up.sh
+++ b/deploy/scripts/kind-up.sh
@@ -110,14 +110,16 @@ if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
   echo "    ANTHROPIC_API_KEY  ✓ injected"
 else
   echo "    ANTHROPIC_API_KEY  ✗ not set"
-  echo "      Live cluster:  kubectl set env deployment/aegis-agents ANTHROPIC_API_KEY=<key> -n ${NAMESPACE}"
-  echo "      Fresh start:   export ANTHROPIC_API_KEY=<key> && ./deploy/scripts/kind-up.sh --skip-build"
+  echo "      How to inject:"
+  echo "        Live cluster:  kubectl set env deployment/aegis-agents ANTHROPIC_API_KEY=<key> -n ${NAMESPACE}"
+  echo "        Fresh start:   export ANTHROPIC_API_KEY=<key> && ./deploy/scripts/kind-up.sh --skip-build"
 fi
 if [ -n "${ANTHROPIC_BASE_URL:-}" ]; then
   echo "    ANTHROPIC_BASE_URL ✓ injected: ${ANTHROPIC_BASE_URL}"
 else
   echo "    ANTHROPIC_BASE_URL ✗ not set (using Anthropic default endpoint)"
-  echo "      Live cluster:  kubectl set env deployment/aegis-agents ANTHROPIC_BASE_URL=<url> -n ${NAMESPACE}"
-  echo "      Fresh start:   export ANTHROPIC_BASE_URL=<url> && ./deploy/scripts/kind-up.sh --skip-build"
+  echo "      How to inject:"
+  echo "        Live cluster:  kubectl set env deployment/aegis-agents ANTHROPIC_BASE_URL=<url> -n ${NAMESPACE}"
+  echo "        Fresh start:   export ANTHROPIC_BASE_URL=<url> && ./deploy/scripts/kind-up.sh --skip-build"
 fi
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/deploy/scripts/kind-up.sh
+++ b/deploy/scripts/kind-up.sh
@@ -59,14 +59,23 @@ if [ "$SKIP_INSTALL" = false ]; then
   done
   helm dependency update "${REPO_ROOT}/deploy/helm/cerberos" >/dev/null
   HELM_SET_ARGS=()
+  echo ""
+  echo "    Anthropic configuration:"
   if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+    echo "      ANTHROPIC_API_KEY  ✓ set (injecting into aegis-agents)"
     HELM_SET_ARGS+=(--set "aegis-agents.anthropicApiKey=${ANTHROPIC_API_KEY}")
   else
-    echo "    (warning: ANTHROPIC_API_KEY not set — aegis-agents will start without it)"
+    echo "      ANTHROPIC_API_KEY  ✗ not set — aegis-agents will start without it"
+    echo "        To inject: export ANTHROPIC_API_KEY=<your-key> then re-run this script"
   fi
   if [ -n "${ANTHROPIC_BASE_URL:-}" ]; then
+    echo "      ANTHROPIC_BASE_URL ✓ set (injecting into aegis-agents): ${ANTHROPIC_BASE_URL}"
     HELM_SET_ARGS+=(--set "aegis-agents.anthropicBaseUrl=${ANTHROPIC_BASE_URL}")
+  else
+    echo "      ANTHROPIC_BASE_URL ✗ not set — using Anthropic default endpoint"
+    echo "        To inject: export ANTHROPIC_BASE_URL=<your-url> then re-run this script"
   fi
+  echo ""
 
   helm upgrade --install cerberos "${REPO_ROOT}/deploy/helm/cerberos" \
     --namespace "${NAMESPACE}" \


### PR DESCRIPTION
## Summary
- `kind-up.sh` now reads `ANTHROPIC_API_KEY` and `ANTHROPIC_BASE_URL` directly from the shell — no manual `--set` flags needed
- Added `ANTHROPIC_BASE_URL` support end-to-end: new `values.yaml` key + conditional `env` entry in the aegis-agents deployment template
- Anthropic env var status (set/not set) printed in the final summary with `How to inject:` instructions for both live clusters and fresh starts
- Added `-h`/`--help` menus to all three deploy scripts (`kind-up.sh`, `kind-down.sh`, `build-and-load.sh`)

## Test plan
- [ ] Run `./deploy/scripts/kind-up.sh -h` — verify help exits immediately without touching the cluster
- [ ] Run `./deploy/scripts/kind-down.sh -h` and `./deploy/scripts/build-and-load.sh -h` — same
- [ ] Export `ANTHROPIC_API_KEY` and run `kind-up.sh` — verify `✓ injected` in summary and env var present in aegis-agents pod
- [ ] Export `ANTHROPIC_BASE_URL` and repeat — verify `✓ injected` in summary and env var in pod
- [ ] Run with neither set — verify `✗ not set` with `How to inject:` instructions appear in summary, cluster still comes up
- [ ] On a live cluster, run the `kubectl set env` command from the summary — verify env var is hot-patched into the pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)