### PR TITLE
feat(io): on-demand credential flow for vault-delegated skills

### DIFF
--- a/agents-component/cmd/agent-process/vault.go
+++ b/agents-component/cmd/agent-process/vault.go
@@ -80,6 +80,14 @@ type VaultExecutor struct {
 	mu                sync.Mutex
 	pending           map[string]chan types.VaultOperationResult    // requestID → result channel
 	progressCallbacks map[string]func(types.VaultOperationProgress) // requestID → onUpdate; at-most-once
+
+	// credMu guards credPending. When N parallel tool calls all hit
+	// MISSING_CREDENTIAL for the same credentialType, only the first goroutine
+	// publishes a credential.request and shows the IO modal. The rest wait on
+	// the shared done channel. When the credential is stored the done channel is
+	// closed, broadcasting to all waiters simultaneously.
+	credMu      sync.Mutex
+	credPending map[string]chan struct{} // credentialType → done channel
 }
 
 // agentEnvelope is the outbound wire format required by the Orchestrator (mirrors
@@ -145,6 +153,7 @@ func NewVaultExecutor(log *slog.Logger, taskID, permissionToken, traceID string)
 		log:               log,
 		pending:           make(map[string]chan types.VaultOperationResult),
 		progressCallbacks: make(map[string]func(types.VaultOperationProgress)),
+		credPending:       make(map[string]chan struct{}),
 	}
 
 	// Durable consumer name is stable per agent_id: survives crash/respawn so
@@ -451,6 +460,14 @@ func (ve *VaultExecutor) Execute(ctx context.Context, operationType, credentialT
 				"operation_type": req.OperationType,
 				"error_code":     vaultResult.ErrorCode,
 			})
+			// When the vault reports a missing credential, ask the user to supply
+			// it via IO and then poll until it appears.
+			// Skip if we're already inside a credential-retry loop (prevents recursion).
+			if vaultResult.ErrorCode == "MISSING_CREDENTIAL" && !isCredentialRetryCtx(ctx) {
+				if retried := ve.requestCredentialAndRetry(ctx, req.OperationType, credentialType, operationParams, timeoutSeconds, onUpdate, toolCallEntryID); retried != nil {
+					return *retried
+				}
+			}
 		}
 		result := vaultResultToToolResult(vaultResult)
 		result.SessionEntryID = toolCallEntryID
@@ -518,6 +535,195 @@ func (ve *VaultExecutor) Execute(ctx context.Context, operationType, credentialT
 				"deadline_seconds": req.TimeoutSeconds + 5,
 			},
 		}
+	}
+}
+
+// credentialRequestTimeout is how long requestCredentialAndRetry polls for the
+// user to enter a missing API key via the IO credential modal before giving up.
+const (
+	credentialRequestTimeout = 5 * time.Minute
+	credentialPollInterval   = 8 * time.Second
+)
+
+// credentialRetryKey is the context key that marks a vault execute call as
+// originating from inside requestCredentialAndRetry. Execute() skips the
+// MISSING_CREDENTIAL retry path when this key is present, preventing infinite
+// recursion when the credential is still missing during a poll attempt.
+type credentialRetryKey struct{}
+
+func withCredentialRetryCtx(ctx context.Context) context.Context {
+	return context.WithValue(ctx, credentialRetryKey{}, true)
+}
+
+func isCredentialRetryCtx(ctx context.Context) bool {
+	return ctx.Value(credentialRetryKey{}) != nil
+}
+
+// credentialUserInputRequest is the wire payload for a user_input credential
+// request sent to aegis.orchestrator.credential.request. The gateway forwards
+// this to IO which surfaces the CredentialModal to the user.
+type credentialUserInputRequest struct {
+	RequestID   string `json:"request_id"`
+	AgentID     string `json:"agent_id"`
+	TaskID      string `json:"task_id"`
+	Operation   string `json:"operation"` // always "user_input"
+	KeyName     string `json:"key_name"`
+	Label       string `json:"label"`
+	Description string `json:"description"`
+}
+
+// requestCredentialAndRetry is called when vault execute returns MISSING_CREDENTIAL.
+//
+// Deduplication: when N parallel tool calls all hit MISSING_CREDENTIAL for the same
+// credentialType, only the FIRST goroutine publishes the credential.request and shows
+// the IO modal. All others wait on the shared doneCh and retry once it closes.
+//
+// The retry loop polls vault_google_search every credentialPollInterval using a
+// retry context (so Execute() does not re-enter this function). This avoids relying
+// on a NATS credential.response subscription, which was unreliable due to stale
+// spawn-time authorize messages being replayed on the same NATS subject.
+//
+// Returns nil if the credential flow cannot be started — the caller returns the
+// original MISSING_CREDENTIAL error to the LLM.
+func (ve *VaultExecutor) requestCredentialAndRetry(
+	ctx context.Context,
+	operationType, credentialType string,
+	operationParams json.RawMessage,
+	timeoutSeconds int,
+	onUpdate func(types.VaultOperationProgress),
+	sessionEntryID string,
+) *ToolResult {
+	if ve.nc == nil {
+		return nil
+	}
+
+	// Deduplication: check if another goroutine is already handling this credential.
+	ve.credMu.Lock()
+	doneCh, alreadyPending := ve.credPending[credentialType]
+	if !alreadyPending {
+		doneCh = make(chan struct{})
+		ve.credPending[credentialType] = doneCh
+	}
+	ve.credMu.Unlock()
+
+	if alreadyPending {
+		// Another goroutine owns the modal — wait for it to finish, then retry.
+		ve.log.Info("vault execute: credential request already in progress — waiting",
+			"credential_type", credentialType,
+		)
+		timer := time.NewTimer(credentialRequestTimeout)
+		defer timer.Stop()
+		select {
+		case <-doneCh:
+			retried := ve.Execute(withCredentialRetryCtx(ctx), operationType, credentialType, operationParams, timeoutSeconds, onUpdate)
+			return &retried
+		case <-ctx.Done():
+			return nil
+		case <-timer.C:
+			r := ToolResult{
+				Content:        fmt.Sprintf("No %s was provided within %s. Add your API key in Settings and try again.", credentialType, credentialRequestTimeout),
+				IsError:        true,
+				SessionEntryID: sessionEntryID,
+			}
+			return &r
+		}
+	}
+
+	// This goroutine is the designated requester — broadcast to waiters when done.
+	defer func() {
+		ve.credMu.Lock()
+		delete(ve.credPending, credentialType)
+		ve.credMu.Unlock()
+		close(doneCh)
+	}()
+
+	// Publish credential.request (user_input) — orchestrator routes to IO modal.
+	credReqID := newUUID()
+	label := credentialLabelFor(credentialType)
+	credReq := credentialUserInputRequest{
+		RequestID:   credReqID,
+		AgentID:     ve.agentID,
+		TaskID:      ve.taskID,
+		Operation:   "user_input",
+		KeyName:     credentialType,
+		Label:       label,
+		Description: fmt.Sprintf("%s requires a %s that has not been stored yet. Please enter it to continue.", operationType, credentialType),
+	}
+	env := agentEnvelope{
+		MessageID:       newUUID(),
+		MessageType:     comms.MsgTypeCredentialRequest,
+		SourceComponent: "agents",
+		CorrelationID:   credReqID,
+		TraceID:         ve.traceID,
+		Timestamp:       time.Now().UTC().Format(time.RFC3339Nano),
+		SchemaVersion:   "1.0",
+		Payload:         credReq,
+	}
+	data, err := json.Marshal(env)
+	if err != nil {
+		ve.log.Warn("vault execute: missing credential — marshal failed", "error", err)
+		return nil
+	}
+	if _, err := ve.js.Publish(comms.SubjectCredentialRequest, data); err != nil {
+		ve.log.Warn("vault execute: missing credential — publish credential.request failed", "error", err)
+		return nil
+	}
+
+	ve.log.Info("vault execute: missing credential — polling for credential, modal shown to user",
+		"request_id", credReqID,
+		"credential_type", credentialType,
+		"poll_interval", credentialPollInterval,
+		"timeout", credentialRequestTimeout,
+	)
+
+	// Poll vault_google_search with withCredentialRetryCtx so Execute() does not
+	// re-enter this function. The poll succeeds as soon as the user stores the key.
+	deadline := time.Now().Add(credentialRequestTimeout)
+	retryCtx := withCredentialRetryCtx(ctx)
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(credentialPollInterval):
+		}
+
+		retried := ve.Execute(retryCtx, operationType, credentialType, operationParams, timeoutSeconds, onUpdate)
+		if code, _ := retried.Details["error_code"].(string); code != "MISSING_CREDENTIAL" {
+			// Either success or a different error — done.
+			ve.log.Info("vault execute: credential poll result",
+				"credential_type", credentialType,
+				"is_error", retried.IsError,
+			)
+			retried.SessionEntryID = sessionEntryID
+			return &retried
+		}
+		ve.log.Info("vault execute: credential still missing, continuing to poll",
+			"credential_type", credentialType,
+		)
+	}
+
+	r := ToolResult{
+		Content:        fmt.Sprintf("No %s was provided within %s. Add your API key in Settings and try again.", credentialType, credentialRequestTimeout),
+		IsError:        true,
+		SessionEntryID: sessionEntryID,
+	}
+	return &r
+}
+
+
+// credentialLabelFor returns a human-readable label for the IO credential modal.
+func credentialLabelFor(credentialType string) string {
+	switch credentialType {
+	case "serper_api_key":
+		return "Serper API Key (Google Search)"
+	case "github_token":
+		return "GitHub Personal Access Token"
+	case "web_api_key":
+		return "Web API Key"
+	case "search_api_key":
+		return "Search API Key (Tavily)"
+	default:
+		return credentialType
 	}
 }
 

--- a/agents-component/internal/skillsconfig/default_skills.yaml
+++ b/agents-component/internal/skillsconfig/default_skills.yaml
@@ -222,8 +222,8 @@ domains:
         label: 'Vault Google Search'
         description: 'Search the web using Google Custom Search API via the Vault. Returns titles, URLs, and snippets for the top results. Use for current information, research, and fact-finding. Do NOT use for private or internal data — use vault_data_read for that. Do NOT include credential values in any parameter.'
         implementation: vault_google_search
-        required_credential_types: [google_search_api_key]
-        timeout_seconds: 35
+        required_credential_types: [serper_api_key]
+        timeout_seconds: 40
         parameters:
           - name: query
             type: string

--- a/io/api/src/index.ts
+++ b/io/api/src/index.ts
@@ -900,7 +900,7 @@ app.get('/api/logs', (c) => {
 // Credential submission
 // =============================================================================
 
-// Credential submission endpoint (proxies to Memory Vault)
+// Credential submission endpoint (proxies to Vault Engine, then notifies agent via NATS)
 // NEVER logs or exposes the credential value in responses or logs
 app.post('/api/credential', async (c) => {
   const body = (await c.req.json()) as {
@@ -918,36 +918,50 @@ app.post('/api/credential', async (c) => {
     key_name: keyName,
   })
 
-  const memoryVaultUrl = process.env.MEMORY_VAULT_URL || 'http://localhost:8080/api/v1/vault';
-  const memoryApiKey = process.env.MEMORY_VAULT_API_KEY || '';
+  const vaultEngineUrl = (process.env.VAULT_ENGINE_URL || 'http://vault:8000').replace(/\/$/, '');
 
   try {
-    const vaultRes = await fetch(`${memoryVaultUrl}/${userId}/secrets`, {
+    const vaultRes = await fetch(`${vaultEngineUrl}/credentials/put`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'X-Internal-API-Key': memoryApiKey,
         'traceparent': c.get('traceparent'),
         'X-Trace-ID': c.get('traceId'),
       },
       body: JSON.stringify({
-        key_name: keyName,
+        user_id: userId,
+        credential_type: keyName,
         value: body.value, // pass through without logging
       }),
     });
 
     if (!vaultRes.ok) {
-      const errText = await vaultRes.text();
+      logFromContext(c, 'error', 'credential', 'vault engine rejected credential put', {
+        key_name: keyName,
+        status: String(vaultRes.status),
+      })
       return c.json(
         {
           taskId,
           requestId,
           keyName,
           status: 'error',
-          error: `Vault returned ${vaultRes.status}: ${errText}`,
+          error: `Vault engine returned ${vaultRes.status}`,
         },
         500,
       );
+    }
+
+    // Notify the waiting agent that the credential is now available.
+    // The agent's Execute() is blocked on aegis.agents.credential.response
+    // for this requestId — publishing here unblocks the retry.
+    if (natsClient?.connected) {
+      natsClient.publishRaw('aegis.agents.credential.response', {
+        request_id: requestId,
+        status: 'granted',
+        permission_token: `io-stored-${userId}-${keyName}`,
+        expires_at: new Date(Date.now() + 3600_000).toISOString(),
+      })
     }
 
     return c.json(
@@ -959,16 +973,20 @@ app.post('/api/credential', async (c) => {
       },
       201,
     );
-  } catch {
-    logFromContext(c, 'warn', 'credential', 'memory vault unavailable; simulating credential storage')
+  } catch (err) {
+    logFromContext(c, 'warn', 'credential', 'vault engine unavailable; credential not stored', {
+      key_name: keyName,
+      error: String(err),
+    })
     return c.json(
       {
         taskId,
         requestId,
         keyName,
-        status: 'stored',
+        status: 'error',
+        error: 'vault engine unavailable',
       },
-      201,
+      502,
     );
   }
 });

--- a/io/api/src/nats/client.ts
+++ b/io/api/src/nats/client.ts
@@ -230,7 +230,7 @@ export function createNatsClient(config: NatsConfig): IONatsClient | null {
       const natsPayload = {
         task_id: task.task_id,
         user_id: task.user_id,
-        required_skill_domains: task.required_skill_domains ?? ['general'],
+        required_skill_domains: task.required_skill_domains ?? [],
         priority: task.priority ?? 5,
         // Runaway backstop for a whole task. Individual phases are already
         // bounded by tighter timers in the orchestrator:

--- a/orchestrator/cmd/orchestrator/main.go
+++ b/orchestrator/cmd/orchestrator/main.go
@@ -217,14 +217,9 @@ func buildRuntime(cfg *config.OrchestratorConfig) (*runtime, error) {
 	gw.RegisterVaultExecuteHandler(taskDispatcher.HandleVaultExecuteRequest)
 
 	// Forward agent user_input credential requests to the IO Component.
-	gw.RegisterCredentialRequestHandler(func(_, taskID, requestID, keyName, label, traceID string) error {
-		return ioClient.PushCredentialRequest(ioclient.CredentialRequestPayload{
-			TaskID:    taskID,
-			RequestID: requestID,
-			KeyName:   keyName,
-			Label:     label,
-		}, traceID)
-	})
+	// HandleCredentialRequest resolves the top-level task_id from the subtask ref
+	// so the credential modal reaches the correct browser SSE stream.
+	gw.RegisterCredentialRequestHandler(taskDispatcher.HandleCredentialRequest)
 
 	healthHandler := health.New(vaultClient, memClient, natsClient, taskMonitor, cfg.NodeID)
 

--- a/orchestrator/internal/dispatcher/dispatcher.go
+++ b/orchestrator/internal/dispatcher/dispatcher.go
@@ -92,6 +92,7 @@ type PlanExecutor interface {
 	Execute(ctx context.Context, plan types.ExecutionPlan, ts *types.TaskState) error
 	HandleSubtaskResult(ctx context.Context, result types.TaskResult) error
 	UserIDForSubtask(orchRef string) (string, bool)
+	TaskStateForSubtask(orchRef string) (*types.TaskState, bool)
 }
 
 // ── Dispatcher ────────────────────────────────────────────────────────────────
@@ -695,6 +696,36 @@ func (d *Dispatcher) HandleVaultExecuteRequest(ctx context.Context, req types.Va
 	return result, err
 }
 
+// HandleCredentialRequest is registered with the Gateway to handle credential.request
+// (operation: "user_input") messages from agents. It resolves the top-level task_id
+// and user_id from the subtask's orchRef so the IO push reaches the correct SSE stream.
+func (d *Dispatcher) HandleCredentialRequest(agentID, subtaskRef, requestID, keyName, label, traceID string) error {
+	var topTaskID, userID string
+
+	// Try direct active-task lookup first (subtaskRef == top-level task_id in some flows).
+	if tsVal, ok := d.activeTasks.Load(subtaskRef); ok {
+		ts := tsVal.(*types.TaskState)
+		topTaskID = ts.TaskID
+		userID = ts.UserID
+	} else if ts, ok := d.executor.TaskStateForSubtask(subtaskRef); ok {
+		topTaskID = ts.TaskID
+		userID = ts.UserID
+	} else {
+		observability.LogFromContext(observability.WithModule(context.Background(), "task_dispatcher")).
+			Warn("credential.request: could not resolve top-level task_id",
+				"agent_id", agentID, "subtask_ref", subtaskRef, "request_id", requestID)
+		return nil
+	}
+
+	return d.io.PushCredentialRequest(ioclient.CredentialRequestPayload{
+		TaskID:      topTaskID,
+		RequestID:   requestID,
+		UserID:      userID,
+		KeyName:     keyName,
+		Label:       label,
+	}, traceID)
+}
+
 // HandlePlanComplete is called by the Plan Executor when all subtasks complete successfully.
 // Writes COMPLETED state, delivers aggregated result to User I/O, revokes credentials.
 func (d *Dispatcher) HandlePlanComplete(ts *types.TaskState, aggregatedResults []types.PriorResult) {
@@ -1136,6 +1167,11 @@ func taskKindForPlannerSpec(maintenance bool) string {
 	return "decomposition"
 }
 
+// allSkillDomains is the full set of registered skill domains in the agents component.
+// Used as the fallback when the task's policy scope carries no domain restrictions
+// (empty Domains = "any domain permitted"). Must stay in sync with default_skills.yaml.
+var allSkillDomains = []string{"web", "data", "comms", "storage", "logs", "google_search", "github", "general"}
+
 // buildDecompositionInstructionsWithFacts renders the planner prompt with an
 // optional list of user facts (from personal_info via the Memory service).
 // When facts is empty the prompt is byte-identical to the historic output so
@@ -1145,7 +1181,9 @@ func taskKindForPlannerSpec(maintenance bool) string {
 func buildDecompositionInstructionsWithFacts(taskID, rawInput string, scope types.PolicyScope, facts []string, systemPrompt string) string {
 	allowedDomains := scope.Domains
 	if len(allowedDomains) == 0 {
-		allowedDomains = []string{"general"}
+		// Empty scope.Domains means "no restriction" — grant the planner access to
+		// all registered skill domains so it can assign the right domain per subtask.
+		allowedDomains = allSkillDomains
 	}
 
 	domains := "[]"
@@ -1192,10 +1230,13 @@ func buildDecompositionInstructionsWithFacts(taskID, rawInput string, scope type
 			"- Do not invent new skill domain names outside the allowed list\n"+
 			"- Use an empty array for depends_on when a subtask has no dependencies\n"+
 			"- Keep the plan concise and executable\n"+
-			"- Only assign a credentialed domain (google_search, github, web, data, comms, storage) to a subtask if the corresponding credential type appears in the available credential types list above\n"+
+			"Skill domain guide: use \"web\" for fetch/parse/extract of known URLs, \"data\" for transforms/reads/writes, \"comms\" for messaging, \"storage\" for file operations, \"logs\" for log queries, \"google_search\" for any Google search or web search query (PREFERRED over web for search tasks), \"github\" for GitHub API calls, \"general\" for reasoning/summarization with no external tools.\n"+
+			"- Prefer \"google_search\" over \"web\" whenever the task is a search query — the system will prompt the user for an API key if it is not yet configured.\n"+
+			"- Only avoid \"google_search\" if the user has explicitly said they do not want to use Google search.\n"+
+			"- The \"web\" domain (web.fetch, web.parse, web.extract) does NOT require credentials — use it for fetching specific known URLs, not for general search.\n"+
 			"Ambiguity handling (CRITICAL):\n"+
 			"- You MUST return a valid execution plan JSON object. NEVER reply with a clarifying question, free-form text, an apology, or anything that is not JSON matching the schema above.\n"+
-			"- If the user's message is ambiguous, conversational, a greeting, or a follow-up that depends on prior context, produce a SINGLE-subtask plan where one %s-domain agent composes a direct natural-language answer using the conversation context provided.\n"+
+			"- If the user's message is ambiguous, conversational, a greeting, or a follow-up that depends on prior context, produce a SINGLE-subtask plan where one general-domain agent composes a direct natural-language answer using the conversation context provided.\n"+
 			"- Treat \"Conversation so far:\" content in the user task as authoritative context for resolving pronouns and references in \"Current message:\".\n"+
 			"Parallelism guidance:\n"+
 			"- Independent subtasks MUST have empty depends_on so the executor can dispatch them in parallel.\n"+
@@ -1205,7 +1246,6 @@ func buildDecompositionInstructionsWithFacts(taskID, rawInput string, scope type
 		taskID,
 		taskID,
 		domains,
-		allowedDomains[0],
 		rawInput,
 	)
 }

--- a/orchestrator/internal/executor/executor.go
+++ b/orchestrator/internal/executor/executor.go
@@ -139,6 +139,26 @@ func (e *PlanExecutor) UserIDForSubtask(orchRef string) (string, bool) {
 	return exec.ts.UserID, true
 }
 
+// TaskStateForSubtask resolves the parent TaskState from a subtask's orchestrator_task_ref.
+// Returns (nil, false) when the orchRef is not found in any active plan.
+// Used by the dispatcher to resolve the top-level task_id and user_id for credential requests.
+func (e *PlanExecutor) TaskStateForSubtask(orchRef string) (*types.TaskState, bool) {
+	planIDVal, ok := e.orchRefToPlan.Load(orchRef)
+	if !ok {
+		return nil, false
+	}
+	planID, _ := planIDVal.(string)
+	execVal, ok := e.activePlans.Load(planID)
+	if !ok {
+		return nil, false
+	}
+	exec, _ := execVal.(*planExecution)
+	if exec == nil || exec.ts == nil {
+		return nil, false
+	}
+	return exec.ts, true
+}
+
 // ── Execute — entry point from Task Dispatcher ────────────────────────────────
 
 // Execute initializes all subtasks as PENDING and dispatches those with no dependencies.

--- a/orchestrator/internal/vaultclient/client.go
+++ b/orchestrator/internal/vaultclient/client.go
@@ -75,25 +75,37 @@ func (c *Client) ValidateAndScope(userID string, requiredSkillDomains []string, 
 		}
 	}
 
-	// Build allowed domains: always "general" + requested + any domain whose
-	// credential the user actually has in the vault.
-	domainsSet := map[string]bool{"general": true}
-	for _, d := range requiredSkillDomains {
-		domainsSet[d] = true
-	}
-	for domain, credTypes := range domainCredTypes {
-		for _, ct := range credTypes {
-			for _, avail := range available {
-				if ct == avail {
-					domainsSet[domain] = true
-					break
+	// Build allowed domains.
+	// When requiredSkillDomains is empty the caller imposes no ceiling —
+	// return empty Domains (nil) so the dispatcher's scope check
+	// (len(scopeDomains)==0 → allow any domain) passes for all subtasks.
+	// This mirrors the "domain policy is permissive" intent: non-credentialed
+	// skills like web.fetch must still be usable even when the user has no
+	// vault credential registered.
+	//
+	// When requiredSkillDomains is non-empty it acts as an explicit ceiling.
+	// We expand it with "general" and any domain the user has credentials for
+	// so the planner can freely use those additional domains.
+	var allowedDomains []string
+	if len(requiredSkillDomains) > 0 {
+		domainsSet := map[string]bool{"general": true}
+		for _, d := range requiredSkillDomains {
+			domainsSet[d] = true
+		}
+		for domain, credTypes := range domainCredTypes {
+			for _, ct := range credTypes {
+				for _, avail := range available {
+					if ct == avail {
+						domainsSet[domain] = true
+						break
+					}
 				}
 			}
 		}
-	}
-	allowedDomains := make([]string, 0, len(domainsSet))
-	for d := range domainsSet {
-		allowedDomains = append(allowedDomains, d)
+		allowedDomains = make([]string, 0, len(domainsSet))
+		for d := range domainsSet {
+			allowedDomains = append(allowedDomains, d)
+		}
 	}
 
 	now := time.Now()


### PR DESCRIPTION
## Summary

Closes the gap between the vault-keys pipeline (PR #168) and the user
experience: users no longer need to pre-configure API keys before running
tasks. The first time a credentialed skill (e.g. `vault_google_search`) is
used, the IO surfaces a secure credential modal mid-task. After the user
submits the key it is stored in OpenBao, and the agent resumes automatically.

## What changed

### IO (`io/`)
- **`/api/credential`** now proxies to `VAULT_ENGINE_URL/credentials/put`
  (was Memory vault) so submitted keys are stored in OpenBao where the vault
  engine can retrieve them
- **`nats/client.ts`**: `required_skill_domains` defaults to `[]` (empty = no
  restriction) instead of `['general']`, restoring the PR #175 permissive-scope
  behavior that was overwritten by the PR #155 merge

### Orchestrator (`orchestrator/`)
- **`dispatcher.go`**: added `allSkillDomains` (all 8 domains including
  `google_search` and `github`) as the planner fallback when scope has no
  restriction; updated planner prompt to prefer `google_search` for search
  tasks even when the credential is not yet stored; added
  `HandleCredentialRequest` which resolves the **top-level task_id** from the
  subtask orchRef so the credential modal reaches the correct browser SSE
  stream (was sending to the subtask ID, so the modal never appeared)
- **`executor.go`**: added `TaskStateForSubtask` to look up parent TaskState
  from a subtask orchRef, used by `HandleCredentialRequest`
- **`vaultclient.go`**: return nil `Domains` when `requiredSkillDomains` is
  empty — restores PR #175 fix overwritten by PR #155 merge
- **`main.go`**: wires `HandleCredentialRequest` replacing the anonymous
  handler that sent to the wrong task_id

### Agents (`agents-component/`)
- **`vault.go`**: when vault execute returns `MISSING_CREDENTIAL`:
  - Publishes ONE `credential.request (user_input)` to show the IO modal
  - Polls `vault_google_search` every 8 seconds until the key appears in
    OpenBao (replaces a NATS subscription approach that was receiving stale
    spawn-time authorize responses)
  - `credPending` deduplication map ensures N parallel tool calls show only
    one modal and all resume together once the key is stored
  - `isCredentialRetryCtx` context flag prevents infinite recursion during
    poll retries
- **`default_skills.yaml`**: restored `serper_api_key` credential type for
  `vault_google_search` (overwritten by PR #155 merge)

### Build fixes
- Removed macOS `* 2.go` duplicate files from `orchestrator/` and `vault/`
  that were causing Docker build failures

## Flow

User: "Search Google for cheapest PS5"
↓
Planner assigns google_search domain (preferred for search tasks)
↓
Agent calls vault_google_search → MISSING_CREDENTIAL
↓
Agent publishes credential.request (user_input) — ONE modal shown
Agent polls every 8s (task stays open, no failure)
↓
User enters Serper API key → stored in OpenBao via Vault Engine
↓
Next poll: vault_google_search succeeds → real Serper results returned
↓
Task completes — key persists for all future tasks



## Test

Verified end-to-end on a fresh bootstrap (empty OpenBao):
1. Send "search google and find me the cheapest PS5"
2. Credential modal appears mid-task for `serper_api_key`
3. Enter key → stored → task resumes automatically after next poll (~8s)
4. Real PS5 pricing returned from Serper Google Search API
5. Subsequent tasks reuse the stored key with no modal

## Notes

- PR #155 (memory-session-context) accidentally overwrote three PR #175
  fixes when it merged after #175. This PR restores all three:
  `vaultclient.go` nil-domains logic, `default_skills.yaml` credential type,
  and `nats/client.ts` default skill domains. The agent-spawn system from
  PR #175 (`HandleAgentSpawnRequest`, `pendingAgentSpawns`) is still missing
  from `dispatcher.go` and should be restored in a separate PR.
