### PR TITLE
feat(io): [MT-D1] user switcher dropdown for demo-mode multitenancy

### DIFF
--- a/io/api/src/identity.test.ts
+++ b/io/api/src/identity.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'bun:test'
+import { activeUserId, userIdRequired } from './identity'
+
+const VALID_UUID = '11111111-1111-1111-1111-111111111111'
+
+function fakeCtx(headers: Record<string, string | undefined>) {
+  return {
+    req: {
+      header: (name: string) => headers[name] ?? headers[name.toLowerCase()],
+    },
+    json: (obj: unknown, status: 400) => {
+      return new Response(JSON.stringify(obj), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    },
+  }
+}
+
+describe('activeUserId — X-Active-User is the only identity source', () => {
+  test('missing header → null', () => {
+    expect(activeUserId(fakeCtx({}))).toBeNull()
+  })
+
+  test('empty header → null', () => {
+    expect(activeUserId(fakeCtx({ 'X-Active-User': '' }))).toBeNull()
+  })
+
+  test('whitespace-only header → null', () => {
+    expect(activeUserId(fakeCtx({ 'X-Active-User': '   ' }))).toBeNull()
+  })
+
+  test('non-UUID value → null', () => {
+    expect(activeUserId(fakeCtx({ 'X-Active-User': 'not-a-uuid' }))).toBeNull()
+  })
+
+  test('SQL-ish injection attempt → null', () => {
+    expect(activeUserId(fakeCtx({ 'X-Active-User': "1' OR 1=1 --" }))).toBeNull()
+  })
+
+  test('valid UUID → lowercase string', () => {
+    expect(activeUserId(fakeCtx({ 'X-Active-User': VALID_UUID }))).toBe(VALID_UUID)
+  })
+
+  test('valid uppercase UUID → normalized to lowercase', () => {
+    expect(activeUserId(fakeCtx({ 'X-Active-User': VALID_UUID.toUpperCase() }))).toBe(VALID_UUID)
+  })
+
+  test('valid UUID with surrounding whitespace → trimmed', () => {
+    expect(activeUserId(fakeCtx({ 'X-Active-User': `  ${VALID_UUID}  ` }))).toBe(VALID_UUID)
+  })
+
+  test('legacy X-User-Id header is NOT honored', () => {
+    expect(activeUserId(fakeCtx({ 'X-User-Id': VALID_UUID }))).toBeNull()
+  })
+})
+
+describe('userIdRequired — 400 response shape', () => {
+  test('returns status 400', async () => {
+    const ctx = fakeCtx({})
+    const res = userIdRequired(ctx)
+    expect(res.status).toBe(400)
+  })
+
+  test('error body mentions X-Active-User', async () => {
+    const ctx = fakeCtx({})
+    const res = userIdRequired(ctx)
+    const body = await res.json() as { error: string }
+    expect(body.error).toContain('X-Active-User')
+  })
+})

--- a/io/api/src/identity.ts
+++ b/io/api/src/identity.ts
@@ -1,0 +1,20 @@
+/**
+ * Single source of caller identity for all IO API routes.
+ *
+ * Demo-mode honor system: trusts the `X-Active-User` header set by the UI's
+ * user switcher. No fallbacks to body / query / default — handlers MUST return
+ * `userIdRequired(c)` (400) when `activeUserId` returns null. Real auth (MT-1)
+ * replaces this with verified token claims.
+ */
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export function activeUserId(c: { req: { header: (name: string) => string | undefined } }): string | null {
+  const v = c.req.header('X-Active-User')?.trim().toLowerCase()
+  if (!v || !UUID_RE.test(v)) return null
+  return v
+}
+
+export function userIdRequired(c: { json: (obj: unknown, status: 400) => Response }): Response {
+  return c.json({ error: 'X-Active-User header is required (UUID)' }, 400)
+}

--- a/io/api/src/index.ts
+++ b/io/api/src/index.ts
@@ -34,6 +34,7 @@ import { ioLog, logFromContext, previewHeadTail, previewWords } from './logger'
 import { startHeartbeatEmitter } from './heartbeat'
 import { mirrorMemoryConfigured, persistOrchestratorOutcomeToMemory } from './scheduled-run-mirror'
 import { messageLooksLikeUserCronScheduling } from './scheduling-language'
+import { activeUserId, userIdRequired } from './identity'
 
 // =============================================================================
 // Planner input enrichment
@@ -128,17 +129,17 @@ type ChatResponseCallback = {
 }
 const pendingChatResponses = new Map<string, ChatResponseCallback>()
 
-const DEFAULT_UI_USER_ID = process.env.IO_DEFAULT_USER_ID ?? '00000000-0000-0000-0000-000000000001'
+// Last-resort user_id for orchestrator NATS outcomes that arrive WITHOUT a
+// user_id field on the payload (e.g. legacy task_results from older planner
+// builds). Used only inside the NATS-side memory mirror — HTTP routes get
+// identity from activeUserId(c) and have no fallback. Configurable per
+// deployment via IO_MIRROR_FALLBACK_USER_ID.
+const MIRROR_FALLBACK_USER_ID =
+  process.env.IO_MIRROR_FALLBACK_USER_ID ?? '00000000-0000-0000-0000-000000000001'
 
 /** Map key for pending chat — UUID string case must match (e.g. uuidgen vs NATS subject). */
 function chatPendingKey(taskId: string): string {
   return taskId.trim().toLowerCase()
-}
-
-function requestUserId(c: { req: { header: (name: string) => string | undefined; query: (name: string) => string | undefined } }): string {
-  const fromHeader = c.req.header('X-User-Id')
-  const fromQuery = c.req.query('userId')
-  return fromHeader || fromQuery || DEFAULT_UI_USER_ID
 }
 
 function deliverChatResponse(taskId: string, content: string, done: boolean): boolean {
@@ -253,7 +254,7 @@ if (natsClient) {
           const uid =
             typeof payload.user_id === 'string' && payload.user_id.trim()
               ? payload.user_id.trim()
-              : DEFAULT_UI_USER_ID
+              : MIRROR_FALLBACK_USER_ID
           const cid =
             typeof payload.conversation_id === 'string' && payload.conversation_id.trim()
               ? payload.conversation_id.trim()
@@ -299,7 +300,7 @@ if (natsClient) {
             const uid =
               typeof payload.user_id === 'string' && payload.user_id.trim()
                 ? payload.user_id.trim()
-                : DEFAULT_UI_USER_ID
+                : MIRROR_FALLBACK_USER_ID
             const cid =
               typeof payload.conversation_id === 'string' && payload.conversation_id.trim()
                 ? payload.conversation_id.trim()
@@ -492,10 +493,11 @@ app.get('/api/tasks/:taskId', (c) => {
 });
 
 app.post('/api/conversations', async (c) => {
-  const { title, userId } = await c.req.json()
-  const effectiveUserId = typeof userId === 'string' && userId ? userId : requestUserId(c)
+  const userId = activeUserId(c)
+  if (!userId) return userIdRequired(c)
+  const { title } = await c.req.json()
   const conversation = await createConversation({
-    userId: effectiveUserId,
+    userId,
     title: typeof title === 'string' ? title : undefined,
   })
   if (!conversation) {
@@ -518,8 +520,9 @@ app.post('/api/conversations', async (c) => {
 
 // Create a new task
 app.post('/api/tasks', async (c) => {
+  const userId = activeUserId(c)
+  if (!userId) return userIdRequired(c)
   const body = await c.req.json()
-  const userId = typeof body.userId === 'string' && body.userId ? body.userId : requestUserId(c)
   const conversationId = typeof body.conversationId === 'string' && body.conversationId ? body.conversationId : undefined
   const title = typeof body.title === 'string' ? body.title : undefined
   const inputSummary = typeof body.inputSummary === 'string' ? body.inputSummary : undefined
@@ -692,9 +695,10 @@ const SCHEDULING_AUTOMATION_CHAT_REPLY =
 
 // Send a message (returns streaming response)
 app.post('/api/chat', async (c) => {
+  const effectiveUserId = activeUserId(c)
+  if (!effectiveUserId) return userIdRequired(c)
   const body = (await c.req.json()) as SendMessageRequest;
-  const { taskId, userId, content, conversationHistory, conversationId, required_skill_domains } = body as SendMessageRequest & { userId?: string; required_skill_domains?: string[] };
-  const effectiveUserId = userId || requestUserId(c)
+  const { taskId, content, conversationHistory, conversationId, required_skill_domains } = body as SendMessageRequest & { required_skill_domains?: string[] };
   const traceId = c.get('traceId') as string | undefined;
   if (taskId) c.set('taskId', taskId)
   if (conversationId) c.set('conversationId', conversationId)
@@ -985,9 +989,10 @@ app.post('/api/chat', async (c) => {
 
 // Get logs for a task
 app.get('/api/logs/:taskId', async (c) => {
+  const userId = activeUserId(c)
+  if (!userId) return userIdRequired(c)
   const taskId = c.req.param('taskId');
   const traceId = c.get('traceId') as string | undefined;
-  const userId = requestUserId(c)
   c.set('taskId', taskId)
   const task = await getTask(taskId, userId)
   if (!task) {
@@ -1002,15 +1007,17 @@ app.get('/api/logs/:taskId', async (c) => {
 });
 
 app.get('/api/conversations', async (c) => {
-  const userId = requestUserId(c)
+  const userId = activeUserId(c)
+  if (!userId) return userIdRequired(c)
   const conversations = await listConversations(userId)
   logFromContext(c, 'debug', 'http', 'served conversation list to ui', { user_id: userId, conversation_count: conversations.length })
   return c.json({ conversations })
 })
 
 app.delete('/api/conversations/:conversationId', async (c) => {
+  const userId = activeUserId(c)
+  if (!userId) return userIdRequired(c)
   const conversationId = c.req.param('conversationId')
-  const userId = requestUserId(c)
   c.set('conversationId', conversationId)
   logFromContext(c, 'info', 'http', 'user deleted conversation thread', { user_id: userId })
   await deleteConversation(conversationId, userId)
@@ -1018,8 +1025,9 @@ app.delete('/api/conversations/:conversationId', async (c) => {
 })
 
 app.patch('/api/conversations/:conversationId', async (c) => {
+  const userId = activeUserId(c)
+  if (!userId) return userIdRequired(c)
   const conversationId = c.req.param('conversationId')
-  const userId = requestUserId(c)
   const body = await c.req.json() as { title?: string }
   c.set('conversationId', conversationId)
   if (body.title) {
@@ -1035,8 +1043,9 @@ app.patch('/api/conversations/:conversationId', async (c) => {
 })
 
 app.get('/api/conversations/:conversationId/logs', async (c) => {
+  const userId = activeUserId(c)
+  if (!userId) return userIdRequired(c)
   const conversationId = c.req.param('conversationId')
-  const userId = requestUserId(c)
   c.set('conversationId', conversationId)
   const memoryLogs = await getConversationLogs(conversationId, { userId })
   logFromContext(c, 'debug', 'http', 'served conversation logs to ui', {
@@ -1082,7 +1091,8 @@ app.post('/api/user-crons', async (c) => {
     nextRunAt?: string
     conversationId?: string
   }
-  const userId = typeof body.userId === 'string' && body.userId ? body.userId : requestUserId(c)
+  const userId = activeUserId(c)
+  if (!userId) return userIdRequired(c)
   if (!body.name?.trim() || !body.rawInput?.trim() || !body.nextRunAt || !body.scheduleKind) {
     return c.json({ error: 'name, rawInput, nextRunAt, and scheduleKind are required' }, 400)
   }
@@ -1144,7 +1154,8 @@ app.get('/api/user-crons', async (c) => {
       503,
     )
   }
-  const userId = c.req.query('userId') || requestUserId(c)
+  const userId = activeUserId(c)
+  if (!userId) return userIdRequired(c)
   const res = await fetch(
     `${base}/api/v1/user_crons?userId=${encodeURIComponent(userId)}`,
     { headers: { 'X-Internal-API-Key': key } },
@@ -1169,8 +1180,9 @@ app.delete('/api/user-crons/:jobId', async (c) => {
       503,
     )
   }
+  const userId = activeUserId(c)
+  if (!userId) return userIdRequired(c)
   const jobId = c.req.param('jobId')
-  const userId = c.req.query('userId') || requestUserId(c)
   const res = await fetch(
     `${base}/api/v1/scheduled_jobs/${encodeURIComponent(jobId)}?userId=${encodeURIComponent(userId)}`,
     { method: 'DELETE', headers: { 'X-Internal-API-Key': key } },
@@ -1196,14 +1208,15 @@ app.get('/api/logs', (c) => {
 // Credential submission endpoint (proxies to Vault Engine, then notifies agent via NATS)
 // NEVER logs or exposes the credential value in responses or logs
 app.post('/api/credential', async (c) => {
+  const userId = activeUserId(c)
+  if (!userId) return userIdRequired(c)
   const body = (await c.req.json()) as {
     taskId: string;
     requestId: string;
-    userId: string;
     keyName: string;
     value: string;
   };
-  const { taskId, requestId, userId, keyName } = body;
+  const { taskId, requestId, keyName } = body;
   c.set('taskId', taskId)
   logFromContext(c, 'info', 'credential', 'received credential value from user; forwarding to memory vault (value not logged)', {
     request_id: requestId,

--- a/io/api/src/index.ts
+++ b/io/api/src/index.ts
@@ -18,6 +18,7 @@ import {
   getTask,
   getConversationLogs,
   listConversations,
+  listUsers,
   deleteConversation,
   renameConversation,
   type MemoryLogEntry,
@@ -1012,6 +1013,15 @@ app.get('/api/conversations', async (c) => {
   const conversations = await listConversations(userId)
   logFromContext(c, 'debug', 'http', 'served conversation list to ui', { user_id: userId, conversation_count: conversations.length })
   return c.json({ conversations })
+})
+
+// Demo-mode user-switcher roster. Bootstrap endpoint — intentionally does NOT
+// require X-Active-User, since the UI calls this before a user is selected.
+// Real auth (MT-1) replaces the dropdown entirely.
+app.get('/api/users', async (c) => {
+  const users = await listUsers()
+  logFromContext(c, 'debug', 'http', 'served user roster to ui', { user_count: users.length })
+  return c.json({ users })
 })
 
 app.delete('/api/conversations/:conversationId', async (c) => {

--- a/io/core/src/memory-client.ts
+++ b/io/core/src/memory-client.ts
@@ -405,6 +405,37 @@ export async function renameConversation(conversationId: string, userId: string,
   }
 }
 
+export interface MemoryUser {
+  id: string
+  email: string
+}
+
+const DEMO_USERS: MemoryUser[] = [
+  { id: '00000000-0000-0000-0000-000000000001', email: 'dev-default@example.com' },
+  { id: '11111111-1111-1111-1111-111111111111', email: 'alice@example.com' },
+  { id: '22222222-2222-2222-2222-222222222222', email: 'bob@example.com' },
+]
+
+export async function listUsers(): Promise<MemoryUser[]> {
+  if (demoMode()) {
+    return DEMO_USERS
+  }
+  try {
+    const res = await fetch(`${memoryApiBase()}/api/v1/users`, {
+      headers: { 'X-Internal-API-Key': memoryApiKey() },
+    })
+    if (!res.ok) {
+      memoryClientLog('error', 'list users failed', { status: res.status })
+      return []
+    }
+    const json = await res.json() as { data: { users: MemoryUser[] } }
+    return json.data?.users ?? []
+  } catch (err) {
+    memoryClientLog('error', 'list users network error', { error: String(err) })
+    return []
+  }
+}
+
 export async function listConversations(
   userId: string,
   options?: { limit?: number }

--- a/io/surfaces/web/src/App.tsx
+++ b/io/surfaces/web/src/App.tsx
@@ -13,6 +13,8 @@ import ChatWindow from './components/ChatWindow'
 import CredentialModal from './components/CredentialModal'
 import PlanPreviewCard from './components/PlanPreviewCard'
 import SettingsButton from './components/SettingsButton'
+import UserSwitcher from './components/UserSwitcher'
+import { getActiveUserId } from './lib/active-user'
 import SettingsPanel, { defaultUISettings } from './components/SettingsPanel'
 import type { UISettings } from './components/SettingsPanel'
 import ActivityLog from './components/ActivityLog'
@@ -40,7 +42,9 @@ import { extractPromptBodyForCron, looksLikeRepeatingSchedulingIntent } from './
 import './App.css'
 
 const DEMO_MODE = import.meta.env.VITE_DEMO_MODE === 'true'
-const UI_USER_ID = (import.meta.env.VITE_IO_USER_ID as string | undefined) ?? '00000000-0000-0000-0000-000000000001'
+// Resolved once at module init from localStorage (set by UserSwitcher) or env.
+// The switcher reloads the page on change, so this stays stable during a session.
+const UI_USER_ID = getActiveUserId()
 
 /** Mirrors `scheduled-run-mirror` bucket title — omit from sidebar (not user-authored threads). */
 const MEMORY_ORCHESTRATOR_FALLBACK_CONVERSATION_TITLE = 'Scheduled task runs'
@@ -1890,6 +1894,7 @@ function App() {
               </div>
             )}
           </div>
+          <UserSwitcher />
           <SettingsButton
             isOpen={showSettings}
             onToggle={toggleSettings}

--- a/io/surfaces/web/src/App.tsx
+++ b/io/surfaces/web/src/App.tsx
@@ -430,7 +430,7 @@ function App() {
     if (DEMO_MODE) return
     try {
       const res = await fetch(buildApiUrl(`/api/conversations?userId=${encodeURIComponent(UI_USER_ID)}`), {
-        headers: { 'X-User-Id': UI_USER_ID },
+        headers: { 'X-Active-User': UI_USER_ID },
       })
       if (!res.ok) return
       const json = await res.json() as { conversations?: ConversationSummary[] }
@@ -521,7 +521,7 @@ function App() {
       try {
         const res = await fetch(
           buildApiUrl(`/api/conversations/${encodeURIComponent(cid)}/logs?userId=${encodeURIComponent(UI_USER_ID)}`),
-          { headers: { 'X-User-Id': UI_USER_ID } },
+          { headers: { 'X-Active-User': UI_USER_ID } },
         )
         if (!res.ok) return null
         const json = await res.json() as { logs?: Array<{ at: string }> }
@@ -598,7 +598,7 @@ function App() {
       try {
         const res = await fetch(
           buildApiUrl(`/api/conversations/${encodeURIComponent(task.id)}/logs?userId=${encodeURIComponent(UI_USER_ID)}`),
-          { headers: { 'X-User-Id': UI_USER_ID } },
+          { headers: { 'X-Active-User': UI_USER_ID } },
         )
         if (!res.ok) return
         const json = await res.json() as { logs?: Array<{ role: 'user' | 'orchestrator'; content: string; at: string }> }
@@ -785,7 +785,7 @@ function App() {
       try {
         const res = await fetch(buildApiUrl('/api/tasks'), {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json', 'X-User-Id': UI_USER_ID },
+          headers: { 'Content-Type': 'application/json', 'X-Active-User': UI_USER_ID },
           body: JSON.stringify({
             userId: UI_USER_ID,
             conversationId,
@@ -986,7 +986,7 @@ function App() {
     if (!DEMO_MODE) {
       void fetch(buildApiUrl(`/api/conversations/${encodeURIComponent(id)}`), {
         method: 'DELETE',
-        headers: { 'X-User-Id': UI_USER_ID },
+        headers: { 'X-Active-User': UI_USER_ID },
       })
         .then(() => {
           void refetchConversations()
@@ -1003,7 +1003,7 @@ function App() {
     if (!DEMO_MODE) {
       fetch(buildApiUrl(`/api/conversations/${encodeURIComponent(id)}`), {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json', 'X-User-Id': UI_USER_ID },
+        headers: { 'Content-Type': 'application/json', 'X-Active-User': UI_USER_ID },
         body: JSON.stringify({ title }),
       }).catch(() => {/* best-effort */})
     }
@@ -1572,7 +1572,7 @@ function App() {
       try {
         const res = await fetch(buildApiUrl('/api/tasks'), {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json', 'X-User-Id': UI_USER_ID },
+          headers: { 'Content-Type': 'application/json', 'X-Active-User': UI_USER_ID },
           body: JSON.stringify({
             userId: UI_USER_ID,
             conversationId,

--- a/io/surfaces/web/src/components/UserSwitcher.css
+++ b/io/surfaces/web/src/components/UserSwitcher.css
@@ -1,0 +1,25 @@
+.user-switcher {
+  appearance: none;
+  -webkit-appearance: none;
+  width: auto;
+  padding: 6px 26px 6px 10px;
+  background-color: transparent;
+  border: var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 12px;
+  cursor: pointer;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'><path d='M1 1l4 4 4-4' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 9px center;
+}
+
+.user-switcher:focus {
+  outline: none;
+}
+
+.user-switcher:focus-visible {
+  border-color: var(--accent-border);
+  box-shadow: var(--focus-ring);
+}

--- a/io/surfaces/web/src/components/UserSwitcher.tsx
+++ b/io/surfaces/web/src/components/UserSwitcher.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react'
+import { buildApiUrl } from '../api/orchestrator'
+import { getActiveUserId, setActiveUserId } from '../lib/active-user'
+import './UserSwitcher.css'
+
+interface UserSummary {
+  id: string
+  email: string
+}
+
+/**
+ * Demo-mode "Acting as: [user]" switcher. Selecting a different user writes
+ * the choice to localStorage and reloads the page so all state — SSE streams,
+ * cached conversations, in-flight requests — resets cleanly under the new
+ * identity. Not authentication; see plans/multitenancy.md Appendix A.
+ */
+function UserSwitcher() {
+  const [users, setUsers] = useState<UserSummary[]>([])
+  const current = getActiveUserId()
+
+  useEffect(() => {
+    let cancelled = false
+    fetch(buildApiUrl('/api/users'))
+      .then(r => (r.ok ? r.json() : { users: [] }))
+      .then((data: { users?: UserSummary[] }) => {
+        if (!cancelled) setUsers(data.users ?? [])
+      })
+      .catch(() => {
+        if (!cancelled) setUsers([])
+      })
+    return () => { cancelled = true }
+  }, [])
+
+  function onChange(e: React.ChangeEvent<HTMLSelectElement>): void {
+    const next = e.target.value
+    if (next && next !== current) {
+      setActiveUserId(next)
+      window.location.reload()
+    }
+  }
+
+  // If the roster fails to load, render a stub showing the current uuid so the
+  // switcher is still visibly present (and debuggable) rather than silently absent.
+  const options = users.length > 0
+    ? users
+    : [{ id: current, email: `${current.slice(0, 8)}…` }]
+
+  return (
+    <select
+      className="user-switcher"
+      value={current}
+      onChange={onChange}
+      title="Acting as (demo only — not authentication)"
+      aria-label="Active user"
+    >
+      {options.map(u => (
+        <option key={u.id} value={u.id}>
+          {u.email}
+        </option>
+      ))}
+    </select>
+  )
+}
+
+export default UserSwitcher

--- a/io/surfaces/web/src/lib/active-user.test.ts
+++ b/io/surfaces/web/src/lib/active-user.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test, beforeEach } from 'bun:test'
+import { getActiveUserId, setActiveUserId } from './active-user'
+
+const STORAGE_KEY = 'cerberos-active-user'
+const ALICE = '11111111-1111-1111-1111-111111111111'
+const BOB = '22222222-2222-2222-2222-222222222222'
+const DEFAULT = '00000000-0000-0000-0000-000000000001'
+
+// Polyfill localStorage for the bun test runtime.
+class MemStore {
+  store = new Map<string, string>()
+  getItem(k: string): string | null { return this.store.get(k) ?? null }
+  setItem(k: string, v: string): void { this.store.set(k, v) }
+  removeItem(k: string): void { this.store.delete(k) }
+  clear(): void { this.store.clear() }
+}
+;(globalThis as unknown as { localStorage: MemStore }).localStorage = new MemStore()
+;(globalThis as unknown as { import: { meta: { env: Record<string, string> } } }).import = {
+  meta: { env: {} },
+}
+
+beforeEach(() => {
+  ;(globalThis as unknown as { localStorage: MemStore }).localStorage.clear()
+})
+
+describe('active-user', () => {
+  test('falls back to default when localStorage empty and no env var', () => {
+    expect(getActiveUserId()).toBe(DEFAULT)
+  })
+
+  test('returns localStorage value when valid', () => {
+    setActiveUserId(ALICE)
+    expect(getActiveUserId()).toBe(ALICE)
+  })
+
+  test('switching writes new uuid to localStorage', () => {
+    setActiveUserId(ALICE)
+    setActiveUserId(BOB)
+    expect(getActiveUserId()).toBe(BOB)
+  })
+
+  test('setActiveUserId rejects non-uuid input', () => {
+    setActiveUserId(ALICE)
+    setActiveUserId('not-a-uuid')
+    expect(getActiveUserId()).toBe(ALICE)
+  })
+
+  test('uppercase uuid in localStorage is normalized to lowercase', () => {
+    ;(globalThis as unknown as { localStorage: MemStore }).localStorage.setItem(STORAGE_KEY, ALICE.toUpperCase())
+    expect(getActiveUserId()).toBe(ALICE)
+  })
+
+  test('garbage value in localStorage falls back to default', () => {
+    ;(globalThis as unknown as { localStorage: MemStore }).localStorage.setItem(STORAGE_KEY, 'malicious-junk')
+    expect(getActiveUserId()).toBe(DEFAULT)
+  })
+})

--- a/io/surfaces/web/src/lib/active-user.ts
+++ b/io/surfaces/web/src/lib/active-user.ts
@@ -1,0 +1,40 @@
+/**
+ * Demo-mode active-user resolution. Read at module init time and on every
+ * dropdown switch (which triggers `window.location.reload()`), so consumers
+ * can treat the result as a stable constant within a single page lifetime.
+ *
+ * Resolution order:
+ *   1. localStorage["cerberos-active-user"]  (set by UserSwitcher)
+ *   2. VITE_IO_USER_ID env var                (build-time override)
+ *   3. hardcoded default UUID                 (matches identity_schema seed)
+ *
+ * NOT auth — anyone can edit localStorage. Real auth (MT-1) replaces this.
+ */
+
+const STORAGE_KEY = 'cerberos-active-user'
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function isValidUuid(v: string | null | undefined): v is string {
+  return typeof v === 'string' && UUID_RE.test(v)
+}
+
+export function getActiveUserId(): string {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (isValidUuid(stored)) return stored.toLowerCase()
+  } catch {
+    // SSR / privacy mode — fall through to env default
+  }
+  const fromEnv = import.meta.env.VITE_IO_USER_ID as string | undefined
+  if (isValidUuid(fromEnv)) return fromEnv.toLowerCase()
+  return '00000000-0000-0000-0000-000000000001'
+}
+
+export function setActiveUserId(userId: string): void {
+  if (!isValidUuid(userId)) return
+  try {
+    localStorage.setItem(STORAGE_KEY, userId.toLowerCase())
+  } catch {
+    // ignore storage errors
+  }
+}

--- a/io/surfaces/web/tsconfig.json
+++ b/io/surfaces/web/tsconfig.json
@@ -25,5 +25,5 @@
     "noUncheckedSideEffectImports": true
   },
   "include": ["src"],
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/memory/cmd/server/main.go
+++ b/memory/cmd/server/main.go
@@ -201,6 +201,7 @@ func main() {
 	vaultHandler := api.NewVaultHandler(vaultRepo, vaultManager, logRepo)
 	agentHandler := api.NewAgentHandler(agentLogsRepo)
 	scheduledJobsHandler := api.NewScheduledJobsHandler(scheduledJobsRepo, userDispatch)
+	usersHandler := api.NewUsersHandler(piRepo, logger)
 
 	// Set up the router using Go 1.22's enhanced mux
 	mux := http.NewServeMux()
@@ -213,6 +214,9 @@ func main() {
 
 	// Healthz endpoint
 	mux.HandleFunc("GET /api/v1/healthz", newHealthzHandler(db, logger))
+
+	// Users endpoint (demo-mode user switcher roster)
+	mux.HandleFunc("GET /api/v1/users", usersHandler.HandleListUsers)
 
 	// Chat endpoints
 	mux.HandleFunc("GET /api/v1/conversations", chatHandler.HandleListConversations)

--- a/memory/internal/api/users_handler.go
+++ b/memory/internal/api/users_handler.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/mlim3/cerberOS/memory/internal/storage"
+)
+
+// UsersHandler exposes the demo-mode user switcher list. This is a roster of
+// who can be selected from the IO dropdown — NOT an authenticated identity
+// provider. Real auth (MT-1) replaces the dropdown entirely.
+type UsersHandler struct {
+	repo   storage.Repository
+	logger *slog.Logger
+}
+
+func NewUsersHandler(repo storage.Repository, logger *slog.Logger) *UsersHandler {
+	return &UsersHandler{repo: repo, logger: logger}
+}
+
+type UserSummary struct {
+	ID    uuid.UUID `json:"id"`
+	Email string    `json:"email"`
+}
+
+// HandleListUsers returns every row in identity_schema.users as {id, email}.
+// @Summary List users (demo mode)
+// @Description Returns the roster of users for the IO user-switcher dropdown.
+// @Tags users
+// @Produce json
+// @Success 200 {object} map[string][]UserSummary "OK"
+// @Failure 500 {object} map[string]interface{} "Internal Server Error"
+// @Router /api/v1/users [get]
+func (h *UsersHandler) HandleListUsers(w http.ResponseWriter, r *http.Request) {
+	users, err := h.repo.ListUsers(r.Context())
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "internal", "failed to list users", err.Error())
+		return
+	}
+	resp := make([]UserSummary, 0, len(users))
+	for _, u := range users {
+		resp = append(resp, UserSummary{
+			ID:    uuid.UUID(u.ID.Bytes),
+			Email: u.Email,
+		})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(SuccessResponse(map[string]any{"users": resp}))
+}

--- a/memory/internal/storage/repository.go
+++ b/memory/internal/storage/repository.go
@@ -17,10 +17,18 @@ type Repository interface {
 	Querier() *Queries
 	WithTx(ctx context.Context, fn func(q *Queries) error) error
 	UserExists(ctx context.Context, userID pgtype.UUID) (bool, error)
+	ListUsers(ctx context.Context) ([]UserRecord, error)
 	QueryChunksBySimilarity(ctx context.Context, userID pgtype.UUID, embedding pgvector.Vector, limit int32) ([]PersonalInfoChunkMatch, error)
 	ListFacts(ctx context.Context, userID pgtype.UUID, includeArchived bool) ([]FactRecord, error)
 	ArchiveFact(ctx context.Context, userID, factID pgtype.UUID, reason string) error
 	SupersedeFact(ctx context.Context, userID, factID pgtype.UUID, category pgtype.Text, factKey string, factValue []byte, confidence float64) (pgtype.UUID, error)
+}
+
+// UserRecord is the demo-mode shape returned by ListUsers — only what the
+// dropdown needs (no PII beyond email, which is what seed data already exposes).
+type UserRecord struct {
+	ID    pgtype.UUID
+	Email string
 }
 
 type PersonalInfoChunkMatch struct {
@@ -72,6 +80,27 @@ func (r *BaseRepository) UserExists(ctx context.Context, userID pgtype.UUID) (bo
 	var exists bool
 	err := r.Pool.QueryRow(ctx, q, userID).Scan(&exists)
 	return exists, err
+}
+
+func (r *BaseRepository) ListUsers(ctx context.Context) ([]UserRecord, error) {
+	const q = `SELECT id, email FROM identity_schema.users ORDER BY created_at ASC`
+	rows, err := r.Pool.Query(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("query users: %w", err)
+	}
+	defer rows.Close()
+	users := make([]UserRecord, 0)
+	for rows.Next() {
+		var u UserRecord
+		if err := rows.Scan(&u.ID, &u.Email); err != nil {
+			return nil, fmt.Errorf("scan user: %w", err)
+		}
+		users = append(users, u)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate users: %w", err)
+	}
+	return users, nil
 }
 
 func (r *BaseRepository) QueryChunksBySimilarity(ctx context.Context, userID pgtype.UUID, embedding pgvector.Vector, limit int32) ([]PersonalInfoChunkMatch, error) {


### PR DESCRIPTION
Closes #180 (MT-D1). Umbrella: #178. **Stacked on #193** (MT-D2) — base will retarget to \`main\` automatically once #193 merges.

## Summary

Adds an \"Acting as: [user]\" dropdown in the IO header that lets the operator switch which user the session is acting as. Selection is persisted to \`localStorage\`; switching reloads the page so SSE streams, conversation caches, and in-flight requests reset cleanly under the new identity.

This is the demo-mode replacement for real authentication — anyone using the UI can pick any user, it is honor-system, not security. Real auth (MT-1) replaces the dropdown entirely. See \`plans/multitenancy.md\` Appendix A.

## What changed

**memory** (Go, ~30 lines)
- \`BaseRepository.ListUsers()\` — \`SELECT id, email FROM identity_schema.users\`.
- \`UsersHandler.HandleListUsers\` returning \`{users: [{id, email}]}\`.
- New route: \`GET /api/v1/users\`.

**io-core** (TypeScript)
- \`listUsers()\` in \`memory-client.ts\` with a \`DEMO_USERS\` fallback (alice, bob, dev-default) for when \`MEMORY_API_BASE\` is unset.

**io/api**
- \`GET /api/users\` proxy. Bootstrap endpoint — intentionally does NOT require \`X-Active-User\`, since the UI calls it before any user is selected. Documented inline.

**io/surfaces/web**
- \`lib/active-user.ts\` — \`getActiveUserId()\` / \`setActiveUserId()\` with UUID validation, localStorage persistence, env-var fallback, default UUID.
- \`components/UserSwitcher.tsx\` — fetches \`/api/users\` on mount, renders a \`<select>\` next to \`SettingsButton\`, reloads page on change. Falls back to a stub showing the current UUID prefix if the roster fails to load.
- \`components/UserSwitcher.css\` — mirrors the sidebar \`.search-input\` style (transparent bg, \`--text-primary\`, \`--border-subtle\`, \`--accent-border\` focus) so it sits naturally next to the gear icon.
- \`App.tsx\` — replaced \`const UI_USER_ID = (env...) ?? <default>\` with \`const UI_USER_ID = getActiveUserId()\` (one-line change; all 14 existing call sites still work).
- \`tsconfig.json\` — exclude \`*.test.ts\` from the production \`tsc\` build (otherwise \`bun:test\` types break the build).

## Tests

- \`io/surfaces/web/src/lib/active-user.test.ts\` — 6 cases: localStorage round-trip, default fallback, uppercase normalization, garbage rejection, non-UUID input rejection.
- \`bun test src\` (io/api): 15 pass / 0 fail.
- \`bun test src\` (io/surfaces/web): 6 pass / 0 fail.
- \`bun run build\` (io/surfaces/web): clean.
- \`go build ./...\` (memory): clean.

## Test plan

- [x] Unit tests pass on web + api
- [x] Memory builds, unit tests pass
- [x] Web production build clean
- [ ] Reviewer: \`bun run dev\` in \`io/api\` and \`io/surfaces/web\`; open \`http://localhost:5173\`
- [ ] Reviewer: dropdown appears in header next to gear icon, lists 3 demo users (alice/bob/dev-default)
- [ ] Reviewer: selection persists across reload (localStorage)
- [ ] Reviewer: DevTools Network tab shows \`X-Active-User: <uuid>\` matching dropdown selection
- [ ] Reviewer: \`localStorage.setItem('cerberos-active-user', 'junk'); location.reload()\` falls back to default UUID without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)