### PR TITLE
fix(orchestrator): [MT-9] drop subtask results with mismatched agent_id

### DIFF
--- a/orchestrator/internal/executor/executor.go
+++ b/orchestrator/internal/executor/executor.go
@@ -294,6 +294,21 @@ func (e *PlanExecutor) HandleSubtaskResult(ctx context.Context, result types.Tas
 	subCtx = observability.WithModule(subCtx, "plan_executor")
 	log = observability.LogFromContext(subCtx)
 
+	// Cross-tenant safety guard: drop the result if it claims to come from a
+	// different agent than the one this subtask was dispatched to. Without this,
+	// a buggy or compromised agent could publish a forged result against another
+	// task's orchestrator_task_ref and have it routed to the wrong user's SSE
+	// stream. The expected agent_id is set at dispatch time (capability response)
+	// and is server-side state, not agent-supplied. (MT-9 / #188)
+	if sub.AgentID != "" && result.AgentID != "" && sub.AgentID != result.AgentID {
+		log.Warn("dropped subtask result: agent_id mismatch (expected vs actual disagree); possible misrouting or forged result",
+			"expected_agent_id", sub.AgentID,
+			"actual_agent_id", result.AgentID,
+			"orchestrator_task_ref", result.OrchestratorTaskRef,
+		)
+		return nil
+	}
+
 	// Revoke credentials for this subtask's agent.
 	if err := e.policy.RevokeCredentials(subCtx, result.OrchestratorTaskRef); err != nil {
 		log.Error("could not revoke credentials for subtask agent; vault tokens may linger until ttl",

--- a/orchestrator/internal/executor/executor_agent_binding_test.go
+++ b/orchestrator/internal/executor/executor_agent_binding_test.go
@@ -1,0 +1,131 @@
+package executor
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/mlim3/cerberOS/orchestrator/internal/types"
+)
+
+// stubPolicy implements PolicyEnforcer with a counter so tests can assert
+// whether RevokeCredentials was called.
+type stubPolicy struct {
+	mu      sync.Mutex
+	revoked []string
+}
+
+func (s *stubPolicy) RevokeCredentials(_ context.Context, orchRef string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.revoked = append(s.revoked, orchRef)
+	return nil
+}
+
+// newTestExecutor builds a minimum PlanExecutor wired with the in-memory state
+// needed for HandleSubtaskResult — no NATS, no DB, no real gateway. Only the
+// policy stub is wired because the mismatch guard sits above the gateway call.
+func newTestExecutor(policy PolicyEnforcer) *PlanExecutor {
+	return &PlanExecutor{policy: policy}
+}
+
+// seedSubtask plumbs orchRef → planID → exec with a single subtask whose
+// expected agent_id is `expectedAgentID`. Returns the subtask state so tests
+// can inspect post-call mutations.
+func seedSubtask(e *PlanExecutor, orchRef, planID, subtaskID, expectedAgentID string) *types.SubtaskState {
+	sub := &types.SubtaskState{
+		SubtaskID: subtaskID,
+		AgentID:   expectedAgentID,
+		State:     types.SubtaskStatePending,
+	}
+	exec := &planExecution{
+		ts:           &types.TaskState{TaskID: "task-1", UserID: "user-A"},
+		subtasks:     map[string]*types.SubtaskState{subtaskID: sub},
+		orchRefIndex: map[string]string{orchRef: subtaskID},
+	}
+	e.activePlans.Store(planID, exec)
+	e.orchRefToPlan.Store(orchRef, planID)
+	return sub
+}
+
+func TestHandleSubtaskResult_DropsMismatchedAgentID(t *testing.T) {
+	policy := &stubPolicy{}
+	e := newTestExecutor(policy)
+
+	sub := seedSubtask(e, "orch-ref-1", "plan-1", "sub-1", "agent-expected")
+
+	err := e.HandleSubtaskResult(context.Background(), types.TaskResult{
+		OrchestratorTaskRef: "orch-ref-1",
+		AgentID:             "agent-IMPOSTER",
+		Success:             true,
+		Result:              []byte(`"forged"`),
+	})
+	if err != nil {
+		t.Fatalf("expected nil (drop), got error: %v", err)
+	}
+
+	if sub.State != types.SubtaskStatePending {
+		t.Errorf("expected subtask to remain PENDING after dropped result, got %q", sub.State)
+	}
+	if sub.Result != nil {
+		t.Errorf("expected subtask Result to remain unset after dropped result, got %s", string(sub.Result))
+	}
+	if sub.CompletedAt != nil {
+		t.Errorf("expected CompletedAt to remain nil after dropped result")
+	}
+	if len(policy.revoked) != 0 {
+		t.Errorf("expected no credential revocation on dropped result, got %v", policy.revoked)
+	}
+}
+
+func TestHandleSubtaskResult_DropsForgedFailure(t *testing.T) {
+	// A failure result from the wrong agent must also be dropped — the symmetric
+	// case prevents a malicious agent from forcing another tenant's task into
+	// a failure state.
+	policy := &stubPolicy{}
+	e := newTestExecutor(policy)
+	sub := seedSubtask(e, "orch-ref-2", "plan-2", "sub-2", "agent-A")
+
+	err := e.HandleSubtaskResult(context.Background(), types.TaskResult{
+		OrchestratorTaskRef: "orch-ref-2",
+		AgentID:             "agent-B",
+		Success:             false,
+		ErrorCode:           "forged-failure",
+	})
+	if err != nil {
+		t.Fatalf("expected nil (drop), got error: %v", err)
+	}
+	if sub.State == types.SubtaskStateFailed {
+		t.Errorf("forged failure was not rejected: subtask transitioned to FAILED")
+	}
+}
+
+func TestHandleSubtaskResult_AllowsEmptyExpectedAgentID(t *testing.T) {
+	// Legacy / fast-path subtasks may not have an expected agent_id set
+	// (the orchestrator only assigns it after a capability response). When
+	// the stored expected agent_id is empty we must NOT drop the result —
+	// otherwise we'd block normal flows. The guard only fires when both
+	// values are non-empty and disagree.
+	//
+	// Past the guard the code hits persistSubtaskState, which needs the
+	// memory client we haven't wired. We tolerate that downstream panic
+	// here — the proof we wanted (RevokeCredentials was reached) lands
+	// before the panic.
+	policy := &stubPolicy{}
+	e := newTestExecutor(policy)
+	seedSubtask(e, "orch-ref-3", "plan-3", "sub-3", "")
+
+	defer func() {
+		_ = recover() // expected: nil-memory panic past the guard
+		if len(policy.revoked) == 0 {
+			t.Errorf("expected guard to allow result with empty expected agent_id (RevokeCredentials should have been reached); got no revocation")
+		}
+	}()
+
+	_ = e.HandleSubtaskResult(context.Background(), types.TaskResult{
+		OrchestratorTaskRef: "orch-ref-3",
+		AgentID:             "agent-anyone",
+		Success:             true,
+		Result:              []byte(`"ok"`),
+	})
+}


### PR DESCRIPTION
Closes #188 (MT-9). Umbrella: #178.

## Summary

Cross-tenant safety guard in \`executor.HandleSubtaskResult\`: when the inbound \`task.result\` claims a different \`agent_id\` than the one this subtask was dispatched to, drop the message with a warn log instead of routing it.

The expected \`agent_id\` is set server-side at capability-response time (\`executor.go:449\`), not agent-supplied. The result's \`agent_id\` is what the publisher claims. If they disagree, the result either came from the wrong agent (bug, misrouting) or was forged (compromised agent trying to write into another task's SSE stream / failure state). Either way: don't route it, don't revoke credentials, don't mutate subtask state.

## Threat model

- **Case A — agent forges \`orchestrator_task_ref\`**: Agent A publishes \`task.result\` with the correlation_id of a task assigned to Agent B. Without this guard, the orchestrator routes A's result to B's user's SSE stream. With it: dropped + warn.
- **Case B — symmetric failure forgery**: forged \`success: false\` would push another tenant's task into \`FAILED\` and revoke their agent's credentials. Same guard catches this.
- **Case C — agent forges both \`correlation_id\` and \`agent_id\`**: not addressed here. NATS-level auth (Phase 3, MT-11/12/13) is the only fix.

## Conservative behavior

The guard is intentionally permissive in legacy paths: if either the stored expected \`AgentID\` *or* the inbound \`result.AgentID\` is empty, the result is allowed through. Mismatch detection only fires when **both** values are non-empty and disagree. This avoids breaking fast-path subtasks where the orchestrator hasn't yet received a capability response.

## Tests

\`orchestrator/internal/executor/executor_agent_binding_test.go\` — 3 cases:
- Forged success result with mismatched agent_id is **dropped**: subtask stays PENDING, no Result/CompletedAt mutation, no credential revoke.
- Symmetric forged **failure** with mismatched agent_id does not transition the subtask to FAILED.
- **Empty** expected \`AgentID\` allows the result through (legacy/fast-path).

\`go test ./internal/executor/\`: ok.

## Note on a pre-existing build failure

\`internal/dispatcher\` tests fail to build on \`main\` already (\`*executorMock\` is missing \`TaskStateForSubtask\`). Confirmed by \`git stash && go test ./internal/dispatcher/\` on a clean checkout. Not introduced by this PR; should be fixed in a follow-up.

## Test plan

- [x] \`go build ./...\` (orchestrator)
- [x] \`go test ./internal/executor/\` 3 new cases pass
- [x] No new test failures elsewhere
- [ ] Reviewer: verify the guard placement is *before* \`policy.RevokeCredentials\` so a forged result doesn't trigger credential revocation
- [ ] Reviewer: confirm the empty-agent-id legacy path is acceptable, or push back if we should be stricter

🤖 Generated with [Claude Code](https://claude.com/claude-code)