### PR TITLE
feat(demo): close E3 skill creation + bundle FP demo polish

### DIFF
--- a/agents-component/cmd/agent-process/skillsynthesis.go
+++ b/agents-component/cmd/agent-process/skillsynthesis.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 	"time"
 
@@ -70,6 +71,7 @@ func synthesizeSkill(
 	log *slog.Logger,
 	domain string,
 	history []anthropic.MessageParam,
+	requestedName string,
 ) (*types.SkillNode, error) {
 	historyJSON, err := json.Marshal(history)
 	if err != nil {
@@ -79,7 +81,7 @@ func synthesizeSkill(
 	resp, err := client.Messages.New(ctx, anthropic.MessageNewParams{
 		Model:     anthropic.ModelClaudeHaiku4_5,
 		MaxTokens: skillSynthesisMaxTokens,
-		System:    []anthropic.TextBlockParam{{Text: skillSynthesisSystemPrompt(domain)}},
+		System:    []anthropic.TextBlockParam{{Text: skillSynthesisSystemPrompt(domain, requestedName)}},
 		Messages: []anthropic.MessageParam{
 			anthropic.NewUserMessage(anthropic.NewTextBlock(fmt.Sprintf(
 				"Extract a reusable skill from this completed task. Output ONLY valid JSON.\n\n%s",
@@ -143,9 +145,41 @@ func synthesizeSkill(
 	return node, nil
 }
 
+// extractRequestedSkillName scans a user message for an explicit
+// "called <name>", "named <name>", or "name it <name>" directive and returns
+// the requested snake_case-friendly identifier (or "" when no directive is
+// found). Allows downstream synthesis to honour the user's exact wording
+// instead of inventing a verb-phrase name.
+//
+// Match policy: case-insensitive, accepts optional quotes, requires the name
+// to look like a valid Go-style identifier (letters/digits/underscore, ≤64
+// chars, must start with a letter or underscore). Anything else is rejected
+// so we never echo user typos straight into the registered skill catalogue.
+var skillNameDirectiveRE = regexp.MustCompile(`(?i)\b(?:called|named|name it|name the skill)\s+["'` + "`" + `]?([A-Za-z_][A-Za-z0-9_]{0,63})["'` + "`" + `]?`)
+
+func extractRequestedSkillName(userMessage string) string {
+	m := skillNameDirectiveRE.FindStringSubmatch(userMessage)
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
+}
+
 // skillSynthesisSystemPrompt returns the system prompt for the synthesis LLM call.
-func skillSynthesisSystemPrompt(domain string) string {
-	return fmt.Sprintf(`You are a skill extraction assistant for the %q domain of an AI agent system.
+// When requestedName is non-empty the LLM is instructed to use that exact name
+// rather than inventing one — this lets users say "create a skill called X"
+// and have X show up in the persisted skill catalogue.
+func skillSynthesisSystemPrompt(domain, requestedName string) string {
+	nameDirective := ""
+	if requestedName != "" {
+		nameDirective = fmt.Sprintf(
+			"\n\nIMPORTANT — the user explicitly named this skill %q in the task. "+
+				"Set name to exactly %q (snake_case, do not paraphrase). "+
+				"Override the snake_case-naming guidance below ONLY for the name field.",
+			requestedName, requestedName,
+		)
+	}
+	return fmt.Sprintf(`You are a skill extraction assistant for the %q domain of an AI agent system.%s
 
 Analyse the completed task conversation and extract ONE reusable skill definition.
 
@@ -173,7 +207,7 @@ Rules:
 - recipe must reference every parameter defined in spec.parameters using {{param_name}} syntax.
 - Generalise the procedure: replace task-specific values with named parameters.
 - If the task used no novel procedure worth reusing (e.g. a trivial single-step lookup),
-  output exactly: {"name":"","label":"","description":""}`, domain)
+  output exactly: {"name":"","label":"","description":""}`, domain, nameDirective)
 }
 
 // attemptSkillSynthesis is the top-level driver called at task completion.
@@ -203,7 +237,12 @@ func attemptSkillSynthesis(
 		"tool_call_count", toolCallCount,
 	)
 
-	node, err := synthesizeSkill(ctx, client, log, spawnCtx.SkillDomain, history)
+	requestedName := extractRequestedSkillName(spawnCtx.OriginalUserMessage)
+	if requestedName != "" {
+		log.Info("skill synthesis: honoring user-specified skill name",
+			"requested_name", requestedName)
+	}
+	node, err := synthesizeSkill(ctx, client, log, spawnCtx.SkillDomain, history, requestedName)
 	if err != nil {
 		log.Warn("skill synthesis: failed", "domain", spawnCtx.SkillDomain, "error", err)
 		return

--- a/agents-component/cmd/agent-process/skillsynthesis.go
+++ b/agents-component/cmd/agent-process/skillsynthesis.go
@@ -155,7 +155,7 @@ func synthesizeSkill(
 // to look like a valid Go-style identifier (letters/digits/underscore, ≤64
 // chars, must start with a letter or underscore). Anything else is rejected
 // so we never echo user typos straight into the registered skill catalogue.
-var skillNameDirectiveRE = regexp.MustCompile(`(?i)\b(?:called|named|name it|name the skill)\s+["'` + "`" + `]?([A-Za-z_][A-Za-z0-9_]{0,63})["'` + "`" + `]?`)
+var skillNameDirectiveRE = regexp.MustCompile(`(?i)\b(?:called|named|name it|name the skill)\s+["'` + "`" + `]?([A-Za-z_][A-Za-z0-9_]{0,63})["'` + "`" + `]?(?:[\s.,;:!?]|$)`)
 
 func extractRequestedSkillName(userMessage string) string {
 	m := skillNameDirectiveRE.FindStringSubmatch(userMessage)

--- a/agents-component/cmd/agent-process/skillsynthesis_test.go
+++ b/agents-component/cmd/agent-process/skillsynthesis_test.go
@@ -58,14 +58,14 @@ func TestShouldSynthesize_ZeroToolCalls(t *testing.T) {
 // ─── skillSynthesisSystemPrompt ───────────────────────────────────────────────
 
 func TestSkillSynthesisSystemPrompt_ContainsDomain(t *testing.T) {
-	prompt := skillSynthesisSystemPrompt("storage")
+	prompt := skillSynthesisSystemPrompt("storage", "")
 	if !strings.Contains(prompt, "storage") {
 		t.Errorf("system prompt must include the domain name; got %q", prompt)
 	}
 }
 
 func TestSkillSynthesisSystemPrompt_ContainsJSONSchema(t *testing.T) {
-	prompt := skillSynthesisSystemPrompt("web")
+	prompt := skillSynthesisSystemPrompt("web", "")
 	for _, field := range []string{`"name"`, `"label"`, `"description"`, `"spec"`} {
 		if !strings.Contains(prompt, field) {
 			t.Errorf("system prompt must include JSON schema field %s", field)
@@ -74,14 +74,14 @@ func TestSkillSynthesisSystemPrompt_ContainsJSONSchema(t *testing.T) {
 }
 
 func TestSkillSynthesisSystemPrompt_ContainsNegativeGuidance(t *testing.T) {
-	prompt := skillSynthesisSystemPrompt("web")
+	prompt := skillSynthesisSystemPrompt("web", "")
 	if !strings.Contains(prompt, "Do NOT") {
 		t.Error("system prompt must instruct LLM to include negative guidance")
 	}
 }
 
 func TestSkillSynthesisSystemPrompt_ContainsFallbackInstruction(t *testing.T) {
-	prompt := skillSynthesisSystemPrompt("web")
+	prompt := skillSynthesisSystemPrompt("web", "")
 	// The fallback for "no reusable procedure" is signaled by empty name.
 	if !strings.Contains(prompt, `{"name":"","label":"","description":""}`) {
 		t.Error("system prompt must include the empty-name fallback JSON example")
@@ -89,10 +89,49 @@ func TestSkillSynthesisSystemPrompt_ContainsFallbackInstruction(t *testing.T) {
 }
 
 func TestSkillSynthesisSystemPrompt_DifferentDomains(t *testing.T) {
-	p1 := skillSynthesisSystemPrompt("web")
-	p2 := skillSynthesisSystemPrompt("data")
+	p1 := skillSynthesisSystemPrompt("web", "")
+	p2 := skillSynthesisSystemPrompt("data", "")
 	if p1 == p2 {
 		t.Error("prompts for different domains must differ")
+	}
+}
+
+func TestSkillSynthesisSystemPrompt_HonoursRequestedName(t *testing.T) {
+	withName := skillSynthesisSystemPrompt("web", "quick_note")
+	if !strings.Contains(withName, "quick_note") {
+		t.Errorf("prompt with requested name must include it; got %q", withName)
+	}
+	if !strings.Contains(withName, "IMPORTANT") {
+		t.Error("prompt with requested name must emphasise the override")
+	}
+	without := skillSynthesisSystemPrompt("web", "")
+	if strings.Contains(without, "IMPORTANT — the user explicitly named") {
+		t.Error("prompt without a requested name must NOT contain the override directive")
+	}
+}
+
+func TestExtractRequestedSkillName(t *testing.T) {
+	cases := []struct {
+		msg  string
+		want string
+	}{
+		{"Create a skill called quick_note that saves text", "quick_note"},
+		{"please make a skill named MyHelper", "MyHelper"},
+		{`Create a skill called "quick_note" that…`, "quick_note"},
+		{"name it data_loader for me", "data_loader"},
+		{"please name the skill paginate_api", "paginate_api"},
+		{"no directive here, just write a file", ""},
+		{"called 123abc is not a valid identifier", ""},
+		// Hyphenated names are rejected on purpose — skills are snake_case in
+		// the registry, so we'd rather fall back to LLM-inferred than echo a
+		// name that violates the schema.
+		{"called my-skill should not match", ""},
+	}
+	for _, c := range cases {
+		got := extractRequestedSkillName(c.msg)
+		if got != c.want {
+			t.Errorf("extractRequestedSkillName(%q) = %q, want %q", c.msg, got, c.want)
+		}
 	}
 }
 
@@ -148,7 +187,7 @@ func TestSynthesizeSkill_ValidResponse(t *testing.T) {
 	client := newSynthClient(t, srv)
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	node, err := synthesizeSkill(context.Background(), client, log, "web", nil)
+	node, err := synthesizeSkill(context.Background(), client, log, "web", nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -180,7 +219,7 @@ func TestSynthesizeSkill_EmptyNameReturnsNil(t *testing.T) {
 	client := newSynthClient(t, srv)
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	node, err := synthesizeSkill(context.Background(), client, log, "web", nil)
+	node, err := synthesizeSkill(context.Background(), client, log, "web", nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error for no-procedure signal: %v", err)
 	}
@@ -198,7 +237,7 @@ func TestSynthesizeSkill_MarkdownFenceStripped(t *testing.T) {
 	client := newSynthClient(t, srv)
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	node, err := synthesizeSkill(context.Background(), client, log, "web", nil)
+	node, err := synthesizeSkill(context.Background(), client, log, "web", nil, "")
 	if err != nil {
 		t.Fatalf("markdown-fenced JSON must parse correctly, got error: %v", err)
 	}
@@ -216,7 +255,7 @@ func TestSynthesizeSkill_PlainFenceStripped(t *testing.T) {
 	client := newSynthClient(t, srv)
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	node, err := synthesizeSkill(context.Background(), client, log, "web", nil)
+	node, err := synthesizeSkill(context.Background(), client, log, "web", nil, "")
 	if err != nil {
 		t.Fatalf("plain-fenced JSON must parse correctly, got error: %v", err)
 	}
@@ -233,7 +272,7 @@ func TestSynthesizeSkill_InvalidJSON_ReturnsError(t *testing.T) {
 	client := newSynthClient(t, srv)
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	node, err := synthesizeSkill(context.Background(), client, log, "web", nil)
+	node, err := synthesizeSkill(context.Background(), client, log, "web", nil, "")
 	if err == nil {
 		t.Errorf("invalid JSON must return an error; got node=%v", node)
 	}
@@ -252,7 +291,7 @@ func TestSynthesizeSkill_ToolContractViolation_ReturnsError(t *testing.T) {
 	client := newSynthClient(t, srv)
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	node, err := synthesizeSkill(context.Background(), client, log, "web", nil)
+	node, err := synthesizeSkill(context.Background(), client, log, "web", nil, "")
 	if err == nil {
 		t.Errorf("Tool Contract violation must return an error; got node=%v", node)
 	}
@@ -270,7 +309,7 @@ func TestSynthesizeSkill_SynthesizedAtIsRecent(t *testing.T) {
 	client := newSynthClient(t, srv)
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	node, err := synthesizeSkill(context.Background(), client, log, "web", nil)
+	node, err := synthesizeSkill(context.Background(), client, log, "web", nil, "")
 	after := time.Now().UTC()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/io/surfaces/web/src/components/AdminPanel.tsx
+++ b/io/surfaces/web/src/components/AdminPanel.tsx
@@ -36,6 +36,26 @@ function AdminPanel({ onClose }: AdminPanelProps): React.ReactElement {
   const [llmProvider, setLlmProvider] = useState<'anthropic' | 'openai'>('anthropic')
   const [llmKey, setLlmKey] = useState('')
   const [llmStatus, setLlmStatus] = useState<{ kind: 'idle' | 'ok' | 'error'; msg?: string }>({ kind: 'idle' })
+  // last4 hint per provider. Backend stores the real key in OpenBao and
+  // intentionally doesn't echo it back, so we capture the last 4 chars
+  // client-side at save time and persist in localStorage to render a
+  // "Stored ✓ (…xxxx)" badge that survives page reloads. This is hint
+  // material only — never the actual secret.
+  const [llmHints, setLlmHints] = useState<Record<'anthropic' | 'openai', string | null>>({
+    anthropic: null,
+    openai: null,
+  })
+
+  useEffect(() => {
+    const read = (provider: 'anthropic' | 'openai'): string | null => {
+      try {
+        return window.localStorage.getItem(`cerberos.llmKeyHint.${provider}`)
+      } catch {
+        return null
+      }
+    }
+    setLlmHints({ anthropic: read('anthropic'), openai: read('openai') })
+  }, [])
 
   // Gmail demo account state (App Password — no OAuth)
   const [gmailEmail, setGmailEmail] = useState('')
@@ -110,12 +130,21 @@ function AdminPanel({ onClose }: AdminPanelProps): React.ReactElement {
         setLlmStatus({ kind: 'error', msg: data.error ?? `failed (${res.status})` })
         return
       }
+      const last4 = llmKey.slice(-4)
+      try {
+        window.localStorage.setItem(`cerberos.llmKeyHint.${llmProvider}`, last4)
+      } catch {
+        // localStorage unavailable (private mode, quota) — non-fatal, the
+        // server still has the real key in OpenBao; we just won't be able
+        // to render the last-4 hint after reload.
+      }
+      setLlmHints((prev) => ({ ...prev, [llmProvider]: last4 }))
       setLlmKey('')
       setLlmStatus({
         kind: 'ok',
         msg: data.requires_restart
-          ? 'Saved. Restart aegis-agents for the new key to take effect.'
-          : 'Saved.',
+          ? `Stored ✓ (${llmProvider} …${last4}). Restart aegis-agents for the new key to take effect.`
+          : `Stored ✓ (${llmProvider} …${last4}).`,
       })
     } catch (err) {
       setLlmStatus({ kind: 'error', msg: err instanceof Error ? err.message : String(err) })
@@ -183,6 +212,10 @@ function AdminPanel({ onClose }: AdminPanelProps): React.ReactElement {
       setNewUserEmail('')
       setNewUserRole('user')
       setRefreshKey((k) => k + 1)
+      // Notify other components (UserSwitcher in the top bar) that the
+      // /api/users response has changed so they can refetch without a
+      // full page reload.
+      window.dispatchEvent(new CustomEvent('cerberos:users-changed'))
     } catch (err) {
       setNewUserStatus({ kind: 'error', msg: err instanceof Error ? err.message : String(err) })
     }
@@ -279,6 +312,12 @@ function AdminPanel({ onClose }: AdminPanelProps): React.ReactElement {
               Stored in OpenBao via the vault engine. After saving, restart
               <code> aegis-agents</code> to pick up the new key.
             </p>
+            {(llmHints.anthropic || llmHints.openai) && (
+              <div className="admin-status-ok admin-llm-hint">
+                {llmHints.anthropic && <div>Anthropic: stored ✓ (…{llmHints.anthropic})</div>}
+                {llmHints.openai && <div>OpenAI: stored ✓ (…{llmHints.openai})</div>}
+              </div>
+            )}
             <form onSubmit={handleSetLlmKey} className="admin-form">
               <div className="admin-row">
                 <label>Provider</label>

--- a/io/surfaces/web/src/components/TaskSidebar.css
+++ b/io/surfaces/web/src/components/TaskSidebar.css
@@ -554,6 +554,25 @@
   text-overflow: ellipsis;
 }
 
+/* Conversation-ID hint line. Sits below .task-update so log correlation is
+   one hover/click away without dominating the sidebar visually. Uses a
+   monospace font to make the prefix scannable against Loki output. */
+.task-cid {
+  font-size: 9px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  color: var(--text-muted);
+  opacity: 0.55;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: help;
+}
+.task-item:hover .task-cid,
+.task-item.selected .task-cid {
+  opacity: 0.9;
+}
+
 .task-eta {
   display: none;
 }

--- a/io/surfaces/web/src/components/TaskSidebar.tsx
+++ b/io/surfaces/web/src/components/TaskSidebar.tsx
@@ -58,6 +58,7 @@ function TaskSidebar({
   const [renameValue, setRenameValue] = useState('')
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
   const [cronActionError, setCronActionError] = useState<string | null>(null)
+  const [copiedCidTaskId, setCopiedCidTaskId] = useState<string | null>(null)
   const renameInputRef = useRef<HTMLInputElement>(null)
 
   const searchLower = searchQuery.trim().toLowerCase()
@@ -121,6 +122,34 @@ function TaskSidebar({
     if (status === 'awaiting_feedback') return 'awaiting'
     if (status === 'working') return 'working'
     return 'completed'
+  }
+
+  // copyConversationId puts the full conversation_id on the clipboard so the
+  // user can paste it into Loki/Grafana queries. We deliberately surface the
+  // copy via a dropdown action (and a hover-revealed short prefix) rather
+  // than always-on text to keep the sidebar density low while still making
+  // the ID one click away for log correlation during the demo.
+  const copyConversationId = async (taskId: string, cid: string) => {
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(cid)
+      } else {
+        const ta = document.createElement('textarea')
+        ta.value = cid
+        ta.style.position = 'fixed'
+        ta.style.opacity = '0'
+        document.body.appendChild(ta)
+        ta.select()
+        document.execCommand('copy')
+        document.body.removeChild(ta)
+      }
+      setCopiedCidTaskId(taskId)
+      window.setTimeout(() => setCopiedCidTaskId((curr) => (curr === taskId ? null : curr)), 1500)
+    } catch {
+      // Clipboard rejected (insecure context, permissions, etc.) — fall back
+      // to a window.prompt so the user can still copy the value manually.
+      window.prompt('Copy conversation ID:', cid)
+    }
   }
 
   return (
@@ -228,6 +257,16 @@ function TaskSidebar({
                         )}
                         <span className="task-title">{task.title}</span>
                         <span className="task-update">{task.lastUpdate}</span>
+                        {/* task.id IS the conversation_id once the first
+                            message has been sent — they're unified by the
+                            backend (see App.tsx newCid swap). Surfacing it
+                            here makes Loki log correlation one click away. */}
+                        <span
+                          className="task-cid"
+                          title={`Conversation ID: ${task.id} — open the task menu to copy`}
+                        >
+                          cid: {task.id.slice(0, 8)}…
+                        </span>
                       </div>
                     </button>
                     <button
@@ -245,6 +284,17 @@ function TaskSidebar({
                       <div className="task-dropdown">
                         <button type="button" className="task-dropdown-item" onClick={() => startRename(task.id, task.title)}>
                           Rename
+                        </button>
+                        <button
+                          type="button"
+                          className="task-dropdown-item"
+                          onClick={() => {
+                            setOpenMenuId(null)
+                            void copyConversationId(task.id, task.id)
+                          }}
+                          title={task.id}
+                        >
+                          {copiedCidTaskId === task.id ? 'Copied!' : 'Copy CID to clipboard'}
                         </button>
                         <button
                           type="button"

--- a/io/surfaces/web/src/components/UserSwitcher.tsx
+++ b/io/surfaces/web/src/components/UserSwitcher.tsx
@@ -17,6 +17,7 @@ interface UserSummary {
  */
 function UserSwitcher() {
   const [users, setUsers] = useState<UserSummary[]>([])
+  const [reloadTick, setReloadTick] = useState(0)
   const current = getActiveUserId()
 
   useEffect(() => {
@@ -30,6 +31,15 @@ function UserSwitcher() {
         if (!cancelled) setUsers([])
       })
     return () => { cancelled = true }
+  }, [reloadTick])
+
+  // Listen for cross-component "users changed" events dispatched by
+  // AdminPanel after a successful Create user. This avoids requiring a
+  // full page reload to pick up the new entry in the switcher dropdown.
+  useEffect(() => {
+    function onUsersChanged() { setReloadTick((t) => t + 1) }
+    window.addEventListener('cerberos:users-changed', onUsersChanged)
+    return () => window.removeEventListener('cerberos:users-changed', onUsersChanged)
   }, [])
 
   function onChange(e: React.ChangeEvent<HTMLSelectElement>): void {

--- a/orchestrator/observability/grafana/dashboards/cerberos-logs.json
+++ b/orchestrator/observability/grafana/dashboards/cerberos-logs.json
@@ -9,7 +9,18 @@
   "panels": [
     {
       "datasource": { "type": "loki", "uid": "loki" },
-      "gridPos": { "h": 18, "w": 24, "x": 0, "y": 0 },
+      "gridPos": { "h": 4, "w": 24, "x": 0, "y": 0 },
+      "id": 2,
+      "type": "text",
+      "title": "How to search",
+      "options": {
+        "mode": "markdown",
+        "content": "**Search across all cerberOS components.** Loki/Grafana/Promtail containers are pre-filtered out at ingest, so this panel only shows app logs.\n\n- Leave the **Search** variable empty to see all logs.\n- Type any substring (e.g. an API key, a trace_id, a task_id) to filter cluster-wide.\n- Use the **Component** variable to narrow to one service.\n\nWhy is this safer than `Explore`? `Explore` rejects label-less queries; this dashboard always supplies `cluster=\"cerberos\"`."
+      }
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 18, "w": 24, "x": 0, "y": 4 },
       "id": 1,
       "options": {
         "dedupStrategy": "none",
@@ -25,7 +36,7 @@
         {
           "datasource": { "type": "loki", "uid": "loki" },
           "editorMode": "code",
-          "expr": "{job=\"docker\", component=~\".+\"}",
+          "expr": "{cluster=\"cerberos\", component=~\"$component\"} |~ \"(?i)$search\"",
           "queryType": "range",
           "refId": "A"
         }
@@ -37,12 +48,35 @@
   "refresh": "10s",
   "schemaVersion": 38,
   "tags": ["cerberos", "loki"],
-  "templating": { "list": [] },
+  "templating": {
+    "list": [
+      {
+        "name": "search",
+        "label": "Search",
+        "type": "textbox",
+        "current": { "text": "", "value": "" },
+        "query": "",
+        "description": "Case-insensitive substring filter applied across all components. Empty = show everything."
+      },
+      {
+        "name": "component",
+        "label": "Component",
+        "type": "query",
+        "datasource": { "type": "loki", "uid": "loki" },
+        "query": "label_values({cluster=\"cerberos\"}, component)",
+        "refresh": 1,
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".+",
+        "current": { "text": "All", "value": "$__all", "selected": true }
+      }
+    ]
+  },
   "time": { "from": "now-15m", "to": "now" },
   "timepicker": {},
   "timezone": "",
   "title": "CerberOS — container logs",
   "uid": "cerberos-logs",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
- agents: honor user-specified skill names ("called X" / "named X") in synthesis prompt — quick_note no longer becomes append_text_to_file
- web: surface conversation_id per task with hover tooltip and "Copy CID to clipboard" menu action for one-click Loki log correlation
- web: auto-refresh user-switcher dropdown when a new user is created via a cerberos:users-changed window event (no page reload required)
- web: AdminPanel renders "Stored ✓ (…last4)" indicator per LLM provider, persisted in localStorage; real key stays in OpenBao
- grafana: cerberos-logs dashboard adds Search + Component template variables and always supplies cluster="cerberos", so the default query never trips Loki's "label selector required" error (loki|grafana|promtail are already dropped at ingest by Promtail)
- docs: extend context/fp-demo-notes.md with the E3 walkthrough, verification commands, and rebuild-only-affected-containers recipe