### PR TITLE
feat(agents): support OpenAI provider for agent runtime

### DIFF
--- a/agents-component/cmd/agent-process/loop.go
+++ b/agents-component/cmd/agent-process/loop.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -143,13 +144,33 @@ type toolOutcome struct {
 // RunLoop returns the final task result, the final history slice (for the caller
 // to thread through the warm process-reuse loop), and any error.
 func RunLoop(ctx context.Context, log *slog.Logger, spawnCtx *SpawnContext, ve *VaultExecutor, steerer *Steerer, as *AgentSpawner, budget *skills.SpecBudget, priorTurns []anthropic.MessageParam, opts ...option.RequestOption) (string, []anthropic.MessageParam, error) {
-	apiKey := os.Getenv("ANTHROPIC_API_KEY")
-	if apiKey == "" {
-		return "", nil, fmt.Errorf("ANTHROPIC_API_KEY environment variable is not set")
+	provider := strings.ToLower(strings.TrimSpace(os.Getenv("LLM_PROVIDER")))
+	if provider == "" {
+		provider = "anthropic"
+		if os.Getenv("ANTHROPIC_API_KEY") == "" && os.Getenv("OPENAI_API_KEY") != "" {
+			provider = "openai"
+		}
 	}
-	clientOpts := append([]option.RequestOption{option.WithAPIKey(apiKey)}, opts...)
-	c := anthropic.NewClient(clientOpts...)
-	client := &c
+	var client *anthropic.Client
+	var openaiClient *openAIClient
+	switch provider {
+	case "openai":
+		c, err := newOpenAIClientFromEnv()
+		if err != nil {
+			return "", nil, err
+		}
+		openaiClient = c
+	case "anthropic":
+		apiKey := os.Getenv("ANTHROPIC_API_KEY")
+		if apiKey == "" {
+			return "", nil, fmt.Errorf("ANTHROPIC_API_KEY environment variable is not set")
+		}
+		clientOpts := append([]option.RequestOption{option.WithAPIKey(apiKey)}, opts...)
+		c := anthropic.NewClient(clientOpts...)
+		client = &c
+	default:
+		return "", nil, fmt.Errorf("unsupported LLM_PROVIDER %q", provider)
+	}
 
 	// LLM response cache (Assignment #9 — LLM caching: Personalization).
 	// Process-lifetime, TTL-bounded, user-scoped. Only end_turn responses are
@@ -169,7 +190,7 @@ func RunLoop(ctx context.Context, log *slog.Logger, spawnCtx *SpawnContext, ve *
 	// caller parameters substituted in. Existing builtins take precedence: a
 	// synthesized name that matches a builtin is skipped (the builtin is more
 	// reliable than the LLM-executed recipe for that operation).
-	if len(spawnCtx.SynthesizedSkills) > 0 {
+	if client != nil && len(spawnCtx.SynthesizedSkills) > 0 {
 		existingNames := make(map[string]bool, len(tools))
 		for _, t := range tools {
 			existingNames[t.Definition.Name] = true
@@ -267,7 +288,13 @@ func RunLoop(ctx context.Context, log *slog.Logger, spawnCtx *SpawnContext, ve *
 			if llmCache.Enabled() && ve != nil {
 				ve.PublishMetricsEvent(types.MetricsEventLLMCacheMiss, "", 0)
 			}
-			apiResp, err := client.Messages.New(ctx, reqParams)
+			var apiResp *anthropic.Message
+			var err error
+			if openaiClient != nil {
+				apiResp, err = openaiClient.messagesNew(ctx, reqParams)
+			} else {
+				apiResp, err = client.Messages.New(ctx, reqParams)
+			}
 			if err != nil {
 				return "", nil, fmt.Errorf("react iter %d: API call: %w", iter, err)
 			}
@@ -303,7 +330,9 @@ func RunLoop(ctx context.Context, log *slog.Logger, spawnCtx *SpawnContext, ve *
 		if resp.StopReason == anthropic.StopReasonEndTurn {
 			for _, block := range resp.Content {
 				if block.Type == "text" && block.Text != "" {
-					attemptSkillSynthesis(ctx, client, log, spawnCtx, sl, ve, history, toolCallCount)
+					if client != nil {
+						attemptSkillSynthesis(ctx, client, log, spawnCtx, sl, ve, history, toolCallCount)
+					}
 					history = append(history, resp.ToParam())
 					persistConversationSnapshot(sl, log, spawnCtx, block.Text, totalTokens)
 					log.Info("model returned end_turn with text reply; finishing task",
@@ -330,7 +359,9 @@ func RunLoop(ctx context.Context, log *slog.Logger, spawnCtx *SpawnContext, ve *
 						"output_tokens", resp.Usage.OutputTokens,
 						"result_preview", logfields.PreviewHeadTail(block.Text, 15, 10),
 					)
-					attemptSkillSynthesis(ctx, client, log, spawnCtx, sl, ve, history, toolCallCount)
+					if client != nil {
+						attemptSkillSynthesis(ctx, client, log, spawnCtx, sl, ve, history, toolCallCount)
+					}
 					history = append(history, resp.ToParam())
 					const truncationNotice = "\n\n_[Response truncated — output token limit reached. Send a follow-up message to continue.]_"
 					persistConversationSnapshot(sl, log, spawnCtx, block.Text+truncationNotice, totalTokens)
@@ -523,7 +554,9 @@ func RunLoop(ctx context.Context, log *slog.Logger, spawnCtx *SpawnContext, ve *
 				"result_preview", logfields.PreviewHeadTail(finalResult, 15, 10),
 				"result_len", len(finalResult),
 				"tool_call_count", toolCallCount)
-			attemptSkillSynthesis(ctx, client, log, spawnCtx, sl, ve, history, toolCallCount)
+			if client != nil {
+				attemptSkillSynthesis(ctx, client, log, spawnCtx, sl, ve, history, toolCallCount)
+			}
 
 			// Close the tool_use → tool_result turn pair BEFORE snapshotting so
 			// the persisted history always ends on a well-formed boundary.

--- a/agents-component/cmd/agent-process/openai.go
+++ b/agents-component/cmd/agent-process/openai.go
@@ -1,0 +1,318 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/anthropics/anthropic-sdk-go"
+)
+
+const defaultOpenAIModel = "gpt-4o-mini"
+
+type openAIClient struct {
+	apiKey  string
+	baseURL string
+	model   string
+	http    *http.Client
+}
+
+type openAIChatRequest struct {
+	Model     string          `json:"model"`
+	Messages  []openAIMessage `json:"messages"`
+	Tools     []openAITool    `json:"tools,omitempty"`
+	MaxTokens int64           `json:"max_tokens"`
+}
+
+type openAIMessage struct {
+	Role       string           `json:"role"`
+	Content    string           `json:"content,omitempty"`
+	ToolCallID string           `json:"tool_call_id,omitempty"`
+	ToolCalls  []openAIToolCall `json:"tool_calls,omitempty"`
+}
+
+type openAITool struct {
+	Type     string         `json:"type"`
+	Function openAIFunction `json:"function"`
+}
+
+type openAIFunction struct {
+	Name        string                 `json:"name"`
+	Description string                 `json:"description,omitempty"`
+	Parameters  map[string]interface{} `json:"parameters"`
+}
+
+type openAIToolCall struct {
+	ID       string                 `json:"id"`
+	Type     string                 `json:"type"`
+	Function openAIToolCallFunction `json:"function"`
+}
+
+type openAIToolCallFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+type openAIChatResponse struct {
+	Choices []struct {
+		FinishReason string        `json:"finish_reason"`
+		Message      openAIMessage `json:"message"`
+	} `json:"choices"`
+	Usage struct {
+		PromptTokens     int64 `json:"prompt_tokens"`
+		CompletionTokens int64 `json:"completion_tokens"`
+	} `json:"usage"`
+	Error *struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+	} `json:"error,omitempty"`
+}
+
+func newOpenAIClientFromEnv() (*openAIClient, error) {
+	apiKey := strings.TrimSpace(getenvFirst("OPENAI_API_KEY", "OPENAI_API_KEY_RUNTIME"))
+	if apiKey == "" {
+		return nil, fmt.Errorf("OPENAI_API_KEY environment variable is not set")
+	}
+	baseURL := strings.TrimRight(strings.TrimSpace(getenvDefault("OPENAI_BASE_URL", "https://api.openai.com/v1")), "/")
+	model := strings.TrimSpace(getenvDefault("OPENAI_MODEL", defaultOpenAIModel))
+	return &openAIClient{apiKey: apiKey, baseURL: baseURL, model: model, http: &http.Client{Timeout: 180 * time.Second}}, nil
+}
+
+func (c *openAIClient) messagesNew(ctx context.Context, params anthropic.MessageNewParams) (*anthropic.Message, error) {
+	messages, err := openAIMessages(params.System, params.Messages)
+	if err != nil {
+		return nil, err
+	}
+	tools, err := openAITools(params.Tools)
+	if err != nil {
+		return nil, err
+	}
+	reqBody := openAIChatRequest{Model: c.model, Messages: messages, Tools: tools, MaxTokens: params.MaxTokens}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal OpenAI request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build OpenAI request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("OpenAI API call: %w", err)
+	}
+	defer resp.Body.Close()
+	var out openAIChatResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode OpenAI response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		msg := resp.Status
+		if out.Error != nil && out.Error.Message != "" {
+			msg = out.Error.Message
+		}
+		return nil, fmt.Errorf("OpenAI API returned %s", msg)
+	}
+	if len(out.Choices) == 0 {
+		return nil, fmt.Errorf("OpenAI response contained no choices")
+	}
+	return openAIChoiceToAnthropic(c.model, out.Choices[0].Message, out.Choices[0].FinishReason, out.Usage.PromptTokens, out.Usage.CompletionTokens)
+}
+
+func openAIMessages(system []anthropic.TextBlockParam, history []anthropic.MessageParam) ([]openAIMessage, error) {
+	messages := make([]openAIMessage, 0, len(history)+1)
+	if len(system) > 0 {
+		parts := make([]string, 0, len(system))
+		for _, block := range system {
+			if block.Text != "" {
+				parts = append(parts, block.Text)
+			}
+		}
+		if len(parts) > 0 {
+			messages = append(messages, openAIMessage{Role: "system", Content: strings.Join(parts, "\n\n")})
+		}
+	}
+	var raw []struct {
+		Role    string            `json:"role"`
+		Content []json.RawMessage `json:"content"`
+	}
+	b, err := json.Marshal(history)
+	if err != nil {
+		return nil, fmt.Errorf("marshal history: %w", err)
+	}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return nil, fmt.Errorf("unmarshal history: %w", err)
+	}
+	for _, msg := range raw {
+		converted, err := openAIConvertMessage(msg.Role, msg.Content)
+		if err != nil {
+			return nil, err
+		}
+		messages = append(messages, converted...)
+	}
+	return messages, nil
+}
+
+func openAIConvertMessage(role string, blocks []json.RawMessage) ([]openAIMessage, error) {
+	var textParts []string
+	var toolCalls []openAIToolCall
+	var messages []openAIMessage
+	for _, raw := range blocks {
+		var block struct {
+			Type      string          `json:"type"`
+			Text      string          `json:"text"`
+			ID        string          `json:"id"`
+			Name      string          `json:"name"`
+			Input     json.RawMessage `json:"input"`
+			ToolUseID string          `json:"tool_use_id"`
+			Content   json.RawMessage `json:"content"`
+			IsError   bool            `json:"is_error"`
+		}
+		if err := json.Unmarshal(raw, &block); err != nil {
+			return nil, fmt.Errorf("unmarshal history block: %w", err)
+		}
+		switch block.Type {
+		case "text":
+			if block.Text != "" {
+				textParts = append(textParts, block.Text)
+			}
+		case "tool_use":
+			toolCalls = append(toolCalls, openAIToolCall{ID: block.ID, Type: "function", Function: openAIToolCallFunction{Name: block.Name, Arguments: rawJSONOrObject(block.Input)}})
+		case "tool_result":
+			messages = append(messages, openAIMessage{Role: "tool", ToolCallID: block.ToolUseID, Content: toolResultText(block.Content, block.IsError)})
+		}
+	}
+	if role == "assistant" {
+		messages = append([]openAIMessage{{Role: "assistant", Content: strings.Join(textParts, "\n"), ToolCalls: toolCalls}}, messages...)
+		return messages, nil
+	}
+	if len(textParts) > 0 {
+		messages = append([]openAIMessage{{Role: "user", Content: strings.Join(textParts, "\n")}}, messages...)
+	}
+	return messages, nil
+}
+
+func openAITools(toolDefs []anthropic.ToolUnionParam) ([]openAITool, error) {
+	tools := make([]openAITool, 0, len(toolDefs))
+	for _, def := range toolDefs {
+		b, err := json.Marshal(def)
+		if err != nil {
+			return nil, fmt.Errorf("marshal tool definition: %w", err)
+		}
+		var raw struct {
+			Name        string                 `json:"name"`
+			Description string                 `json:"description"`
+			InputSchema map[string]interface{} `json:"input_schema"`
+		}
+		if err := json.Unmarshal(b, &raw); err != nil {
+			return nil, fmt.Errorf("unmarshal tool definition: %w", err)
+		}
+		if raw.Name == "" {
+			continue
+		}
+		if raw.InputSchema == nil {
+			raw.InputSchema = map[string]interface{}{"type": "object"}
+		}
+		tools = append(tools, openAITool{Type: "function", Function: openAIFunction{Name: raw.Name, Description: raw.Description, Parameters: raw.InputSchema}})
+	}
+	return tools, nil
+}
+
+func openAIChoiceToAnthropic(model string, msg openAIMessage, finishReason string, inputTokens, outputTokens int64) (*anthropic.Message, error) {
+	stopReason := "end_turn"
+	if finishReason == "tool_calls" || len(msg.ToolCalls) > 0 {
+		stopReason = "tool_use"
+	} else if finishReason == "length" {
+		stopReason = "max_tokens"
+	}
+	content := make([]map[string]interface{}, 0, 1+len(msg.ToolCalls))
+	if msg.Content != "" {
+		content = append(content, map[string]interface{}{"type": "text", "text": msg.Content})
+	}
+	for _, tc := range msg.ToolCalls {
+		var input interface{}
+		if strings.TrimSpace(tc.Function.Arguments) == "" {
+			input = map[string]interface{}{}
+		} else if err := json.Unmarshal([]byte(tc.Function.Arguments), &input); err != nil {
+			input = map[string]interface{}{"raw_arguments": tc.Function.Arguments}
+		}
+		content = append(content, map[string]interface{}{"type": "tool_use", "id": tc.ID, "name": tc.Function.Name, "input": input})
+	}
+	raw := map[string]interface{}{
+		"id":          "openai-chat-completion",
+		"type":        "message",
+		"role":        "assistant",
+		"model":       model,
+		"stop_reason": stopReason,
+		"content":     content,
+		"usage": map[string]interface{}{
+			"input_tokens":                inputTokens,
+			"output_tokens":               outputTokens,
+			"cache_creation_input_tokens": 0,
+			"cache_read_input_tokens":     0,
+		},
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return nil, err
+	}
+	var out anthropic.Message
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, fmt.Errorf("convert OpenAI response: %w", err)
+	}
+	return &out, nil
+}
+
+func toolResultText(raw json.RawMessage, isError bool) string {
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &blocks); err == nil {
+		parts := make([]string, 0, len(blocks))
+		for _, block := range blocks {
+			if block.Text != "" {
+				parts = append(parts, block.Text)
+			}
+		}
+		if len(parts) > 0 {
+			if isError {
+				return "ERROR: " + strings.Join(parts, "\n")
+			}
+			return strings.Join(parts, "\n")
+		}
+	}
+	if isError {
+		return "ERROR: " + string(raw)
+	}
+	return string(raw)
+}
+
+func rawJSONOrObject(raw json.RawMessage) string {
+	if len(raw) == 0 || strings.TrimSpace(string(raw)) == "" {
+		return "{}"
+	}
+	return string(raw)
+}
+
+func getenvFirst(keys ...string) string {
+	for _, key := range keys {
+		if val := strings.TrimSpace(getenvDefault(key, "")); val != "" {
+			return val
+		}
+	}
+	return ""
+}
+
+func getenvDefault(key, fallback string) string {
+	if val := os.Getenv(key); val != "" {
+		return val
+	}
+	return fallback
+}

--- a/agents-component/internal/lifecycle/firecracker.go
+++ b/agents-component/internal/lifecycle/firecracker.go
@@ -417,7 +417,11 @@ func fcGuestEnv(config VMConfig) map[string]string {
 	}
 	// Forward host env vars that the agent-process needs inside the guest.
 	for _, key := range []string{
+		"LLM_PROVIDER",
 		"ANTHROPIC_API_KEY",
+		"OPENAI_API_KEY",
+		"OPENAI_BASE_URL",
+		"OPENAI_MODEL",
 		"AEGIS_NATS_URL",
 		"AEGIS_AGENT_PROCESS_PATH", // in case the guest needs to respawn
 		"AEGIS_SKILL_SPEC_BUDGET",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -414,8 +414,12 @@ services:
     environment:
       AEGIS_NATS_URL: nats://nats:4222
       AEGIS_AGENT_PROCESS_PATH: /app/agent-process
+      LLM_PROVIDER: ${LLM_PROVIDER:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       ANTHROPIC_BASE_URL: ${ANTHROPIC_BASE_URL:-https://api.anthropic.com}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      OPENAI_BASE_URL: ${OPENAI_BASE_URL:-https://api.openai.com/v1}
+      OPENAI_MODEL: ${OPENAI_MODEL:-gpt-4o-mini}
       # Concurrency cap for inbound task dispatch. Without parallel workers,
       # JetStream delivers task.inbound serially and each HandleTaskSpec
       # (Firecracker provision) blocks subsequent tasks — two back-to-back


### PR DESCRIPTION
Add an OpenAI chat-completions adapter for agent-process and select it with LLM_PROVIDER=openai or when only OPENAI_API_KEY is configured.

Forward OpenAI provider configuration through Docker Compose and Firecracker guest envs so local and VM agent execution can use the saved OpenAI key.