### PR TITLE
fix(io): [MT-2 + MT-3] reject userId override + re-key in-process task state by (userId, taskId)

### DIFF
--- a/io/api/src/identity.test.ts
+++ b/io/api/src/identity.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, test } from 'bun:test'
-import { activeUserId, userIdRequired } from './identity'
+import { activeUserId, assertNoUserIdOverride, userIdRequired } from './identity'
 
 const VALID_UUID = '11111111-1111-1111-1111-111111111111'
+const OTHER_UUID = '22222222-2222-2222-2222-222222222222'
 
-function fakeCtx(headers: Record<string, string | undefined>) {
+function fakeCtx(headers: Record<string, string | undefined>, query: Record<string, string | undefined> = {}) {
   return {
     req: {
       header: (name: string) => headers[name] ?? headers[name.toLowerCase()],
+      query: (name: string) => query[name],
     },
-    json: (obj: unknown, status: 400) => {
+    json: (obj: unknown, status: number) => {
       return new Response(JSON.stringify(obj), {
         status,
         headers: { 'Content-Type': 'application/json' },
@@ -67,5 +69,75 @@ describe('userIdRequired — 400 response shape', () => {
     const res = userIdRequired(ctx)
     const body = await res.json() as { error: string }
     expect(body.error).toContain('X-Active-User')
+  })
+})
+
+describe('assertNoUserIdOverride — MT-2 hard reject body/query userId mismatch', () => {
+  test('body without userId → null (pass-through)', () => {
+    const ctx = fakeCtx({})
+    expect(assertNoUserIdOverride(ctx, { title: 'hi' }, VALID_UUID)).toBeNull()
+  })
+
+  test('null body → null (pass-through, used by DELETE/GET writes)', () => {
+    const ctx = fakeCtx({})
+    expect(assertNoUserIdOverride(ctx, null, VALID_UUID)).toBeNull()
+  })
+
+  test('body.userId matches active user → null (silent accept, back-compat)', () => {
+    const ctx = fakeCtx({})
+    expect(assertNoUserIdOverride(ctx, { userId: VALID_UUID }, VALID_UUID)).toBeNull()
+  })
+
+  test('body.userId matches active user (case-insensitive) → null', () => {
+    const ctx = fakeCtx({})
+    expect(assertNoUserIdOverride(ctx, { userId: VALID_UUID.toUpperCase() }, VALID_UUID)).toBeNull()
+  })
+
+  test('body.userId differs from active user → 403', async () => {
+    const ctx = fakeCtx({})
+    const res = assertNoUserIdOverride(ctx, { userId: OTHER_UUID }, VALID_UUID)
+    expect(res).not.toBeNull()
+    expect(res!.status).toBe(403)
+    const errBody = await res!.json() as { error: string }
+    expect(errBody.error).toContain('X-Active-User')
+  })
+
+  test('attacker scenario: body.userId=<victim> + X-Active-User=<attacker> → 403', async () => {
+    const attacker = VALID_UUID
+    const victim = OTHER_UUID
+    const ctx = fakeCtx({ 'X-Active-User': attacker })
+    expect(activeUserId(ctx)).toBe(attacker)
+    const res = assertNoUserIdOverride(ctx, { userId: victim }, attacker)
+    expect(res).not.toBeNull()
+    expect(res!.status).toBe(403)
+  })
+
+  test('query string userId mismatch → 403', () => {
+    const ctx = fakeCtx({}, { userId: OTHER_UUID })
+    const res = assertNoUserIdOverride(ctx, {}, VALID_UUID)
+    expect(res).not.toBeNull()
+    expect(res!.status).toBe(403)
+  })
+
+  test('query string userId matches active user → null', () => {
+    const ctx = fakeCtx({}, { userId: VALID_UUID })
+    expect(assertNoUserIdOverride(ctx, {}, VALID_UUID)).toBeNull()
+  })
+
+  test('non-object body (string/number) → null (nothing to override)', () => {
+    const ctx = fakeCtx({})
+    expect(assertNoUserIdOverride(ctx, 'oops', VALID_UUID)).toBeNull()
+    expect(assertNoUserIdOverride(ctx, 42, VALID_UUID)).toBeNull()
+  })
+
+  test('non-string body.userId is ignored (no false 403)', () => {
+    const ctx = fakeCtx({})
+    expect(assertNoUserIdOverride(ctx, { userId: 12345 }, VALID_UUID)).toBeNull()
+    expect(assertNoUserIdOverride(ctx, { userId: null }, VALID_UUID)).toBeNull()
+  })
+
+  test('whitespace-padded matching userId → null', () => {
+    const ctx = fakeCtx({})
+    expect(assertNoUserIdOverride(ctx, { userId: `  ${VALID_UUID}  ` }, VALID_UUID)).toBeNull()
   })
 })

--- a/io/api/src/identity.ts
+++ b/io/api/src/identity.ts
@@ -30,6 +30,46 @@ export function userIdRequired(c: { json: (obj: unknown, status: 400) => Respons
   return c.json({ error: 'X-Active-User header is required (UUID)' }, 400)
 }
 
+/**
+ * MT-2: defense-in-depth against userId-override on write endpoints.
+ *
+ * Returns a 403 Response when the request carries a `userId` in the JSON body
+ * or query string that does not match `activeId` (the X-Active-User reader's
+ * result). A matching value is silently accepted for backward compatibility
+ * with older clients that still echo their own id back.
+ *
+ * Handlers MUST short-circuit on a non-null return:
+ *   const denied = assertNoUserIdOverride(c, body, userId)
+ *   if (denied) return denied
+ *
+ * The silent-drop behavior left by MT-D2 (#193) is safe but unobservable;
+ * this turns "your override was ignored" into a hard, auditable boundary.
+ */
+export function assertNoUserIdOverride(
+  c: {
+    req: { query: (name: string) => string | undefined }
+    json: (obj: unknown, status: 403) => Response
+  },
+  body: unknown,
+  activeId: string,
+): Response | null {
+  const active = activeId.toLowerCase()
+  const fromBody =
+    body && typeof body === 'object' && 'userId' in body && typeof (body as { userId?: unknown }).userId === 'string'
+      ? ((body as { userId: string }).userId).trim().toLowerCase()
+      : null
+  const fromQuery = c.req.query('userId')?.trim().toLowerCase() || null
+  for (const candidate of [fromBody, fromQuery]) {
+    if (candidate && candidate !== active) {
+      return c.json(
+        { error: 'userId override does not match X-Active-User' },
+        403,
+      )
+    }
+  }
+  return null
+}
+
 const ROLE_RANK: Record<UserRole, number> = { user: 0, manager: 1, root: 2 }
 
 export async function getActiveRole(userId: string): Promise<UserRole | null> {

--- a/io/api/src/index.ts
+++ b/io/api/src/index.ts
@@ -38,6 +38,22 @@ import { startHeartbeatEmitter } from './heartbeat'
 import { mirrorMemoryConfigured, persistOrchestratorOutcomeToMemory } from './scheduled-run-mirror'
 import { messageLooksLikeUserCronScheduling } from './scheduling-language'
 import { activeUserId, userIdRequired, requireRole, assertNoUserIdOverride } from './identity'
+import {
+  broadcastStatus,
+  broadcastStreamEvent,
+  chatPendingKey,
+  deliverChatResponse,
+  dropPendingChatCallback,
+  failPendingChatCallback,
+  getTaskStatus,
+  listTasksForUser,
+  ownerOfTask,
+  persistAndBroadcastStatus,
+  recordTaskOwnership,
+  registerPendingChatCallback,
+  setTaskStatus,
+  subscribeSse,
+} from './task-scope'
 
 // =============================================================================
 // Planner input enrichment
@@ -122,15 +138,8 @@ ioLog(
 startHeartbeatEmitter(natsClient)
 
 // =============================================================================
-// Pending chat responses — POST /api/chat registers here, orchestrator delivers
+// Pending chat responses — POST /api/chat registers via task-scope, orchestrator delivers
 // =============================================================================
-
-type ChatResponseCallback = {
-  push: (content: string) => void
-  complete: () => void
-  error: (msg: string) => void
-}
-const pendingChatResponses = new Map<string, ChatResponseCallback>()
 
 // Last-resort user_id for orchestrator NATS outcomes that arrive WITHOUT a
 // user_id field on the payload (e.g. legacy task_results from older planner
@@ -139,23 +148,6 @@ const pendingChatResponses = new Map<string, ChatResponseCallback>()
 // deployment via IO_MIRROR_FALLBACK_USER_ID.
 const MIRROR_FALLBACK_USER_ID =
   process.env.IO_MIRROR_FALLBACK_USER_ID ?? '00000000-0000-0000-0000-000000000001'
-
-/** Map key for pending chat — UUID string case must match (e.g. uuidgen vs NATS subject). */
-function chatPendingKey(taskId: string): string {
-  return taskId.trim().toLowerCase()
-}
-
-function deliverChatResponse(taskId: string, content: string, done: boolean): boolean {
-  const key = chatPendingKey(taskId)
-  const cb = pendingChatResponses.get(key)
-  if (!cb) return false
-  cb.push(content)
-  if (done) {
-    cb.complete()
-    pendingChatResponses.delete(key)
-  }
-  return true
-}
 
 function parseEnvelopePayload(env: Record<string, unknown>): Record<string, unknown> {
   const p = env.payload
@@ -239,16 +231,27 @@ if (natsClient) {
     const msgType = envelope.message_type as string | undefined
     const taskId = clientTaskIdFromIOResults(subject, payload)
 
+    // MT-3: orchestrator payloads carry only taskId — resolve owner via reverse index.
+    // If the task is unknown (race during restart, orphan task_result), fall through
+    // to the legacy memory-mirror path (which has its own MIRROR_FALLBACK_USER_ID).
+    const ownerFromPayload =
+      typeof payload.user_id === 'string' && payload.user_id.trim()
+        ? payload.user_id.trim().toLowerCase()
+        : undefined
+    const ownerUserId = taskId ? (ownerOfTask(taskId) ?? ownerFromPayload) : undefined
+
     if (msgType === 'task_accepted') {
-      if (taskId) {
-        deliverChatResponse(taskId, 'Task accepted — the orchestrator is working on it.\n', false)
+      if (taskId && ownerUserId) {
+        deliverChatResponse(ownerUserId, taskId, 'Task accepted — the orchestrator is working on it.\n', false)
         ioLog('info', 'nats', 'orchestrator accepted task; relaying acknowledgment to chat stream', { task_id: taskId })
+      } else if (taskId) {
+        ioLog('warn', 'nats', 'orchestrator task_accepted arrived but task owner unknown; dropping ack', { task_id: taskId })
       }
     } else if (msgType === 'task_result') {
       const result = payload.result as unknown
       const content = extractHumanResult(result)
       if (taskId) {
-        const streamed = deliverChatResponse(taskId, content, true)
+        const streamed = ownerUserId ? deliverChatResponse(ownerUserId, taskId, content, true) : false
         ioLog('info', 'nats', 'orchestrator returned final task result; closing chat stream', {
           task_id: taskId,
           result_preview: previewHeadTail(content),
@@ -284,17 +287,16 @@ if (natsClient) {
     } else if (msgType === 'error_response') {
       const userMsg = (payload.user_message ?? 'An error occurred.') as string
       const errKey = pendingKeyFromErrorPayload(payload, subject)
+      const errOwner = errKey ? (ownerOfTask(errKey) ?? ownerFromPayload) : undefined
       if (errKey) {
-        const cb = pendingChatResponses.get(errKey)
-        if (cb) {
-          cb.error(userMsg)
-          pendingChatResponses.delete(errKey)
+        const failed = errOwner ? failPendingChatCallback(errOwner, errKey, userMsg) : false
+        if (failed) {
           ioLog('warn', 'nats', 'orchestrator returned error_response; failing waiting chat stream', {
             task_id: errKey,
             detail_preview: previewHeadTail(userMsg),
           })
         } else {
-          ioLog('warn', 'nats', 'orchestrator returned error_response but no chat stream is waiting (client disconnected or task_id mismatch)', {
+          ioLog('warn', 'nats', 'orchestrator returned error_response but no chat stream is waiting (client disconnected, task_id mismatch, or owner unknown)', {
             task_id: errKey,
             subject,
             detail_preview: previewHeadTail(userMsg),
@@ -323,10 +325,8 @@ if (natsClient) {
 }
 
 // =============================================================================
-// In-memory task state (separate from log persistence)
+// In-memory task state lives in ./task-scope (MT-3: (userId, taskId) scoped)
 // =============================================================================
-
-const tasks = new Map<string, StatusUpdate>();
 
 /** Maps MemoryLogEntry (user|assistant) back to LogEntry (user|orchestrator). */
 function memoryToLogEntry(m: MemoryLogEntry): LogEntry {
@@ -338,46 +338,7 @@ function memoryToLogEntry(m: MemoryLogEntry): LogEntry {
   }
 }
 
-type SsePush = (bytes: Uint8Array) => void;
-const sseClients = new Map<string, Set<SsePush>>();
-
 const text = new TextEncoder();
-
-function subscribeSse(taskId: string, push: SsePush): () => void {
-  let set = sseClients.get(taskId);
-  if (!set) {
-    set = new Set();
-    sseClients.set(taskId, set);
-  }
-  set.add(push);
-  return () => {
-    set!.delete(push);
-    if (set!.size === 0) sseClients.delete(taskId);
-  };
-}
-
-function broadcastStreamEvent(taskId: string, event: OrchestratorStreamEvent): void {
-  const line = `data: ${JSON.stringify(event)}\n\n`;
-  const bytes = text.encode(line);
-  const set = sseClients.get(taskId);
-  if (!set) return;
-  for (const push of set) {
-    try {
-      push(bytes);
-    } catch {
-      /* client disconnected */
-    }
-  }
-}
-
-function broadcastStatus(taskId: string, status: StatusUpdate): void {
-  broadcastStreamEvent(taskId, { type: 'status', payload: status });
-}
-
-function persistAndBroadcastStatus(status: StatusUpdate): void {
-  tasks.set(status.taskId, status);
-  broadcastStatus(status.taskId, status);
-}
 
 // =============================================================================
 // Demo mode only: mock response generator and demo credential
@@ -475,18 +436,28 @@ app.get('/api/status', (c) => {
 // Conversation / Task endpoints
 // =============================================================================
 
-// Get all tasks
+// Get all tasks owned by the active user.
+// MT-3: the in-memory map is scoped by (userId, taskId); prefix-scan the
+// caller's slot so one user can never see another's live task list.
 app.get('/api/tasks', (c) => {
-  logFromContext(c, 'debug', 'http', 'listed in-memory task statuses for ui')
-  const taskList = Array.from(tasks.values());
+  const userId = activeUserId(c)
+  if (!userId) return userIdRequired(c)
+  const taskList = listTasksForUser(userId)
+  logFromContext(c, 'debug', 'http', 'listed in-memory task statuses for ui', {
+    user_id: userId,
+    task_count: taskList.length,
+  })
   return c.json({ tasks: taskList });
 });
 
-// Get status for a specific task
+// Get status for a specific task. MT-3: lookup by (activeUserId, taskId); 404
+// (not 403) on miss so probing doesn't leak whether another user owns the id.
 app.get('/api/tasks/:taskId', (c) => {
+  const userId = activeUserId(c)
+  if (!userId) return userIdRequired(c)
   const taskId = c.req.param('taskId');
   c.set('taskId', taskId)
-  const task = tasks.get(taskId);
+  const task = getTaskStatus(userId, taskId);
   if (!task) {
     logFromContext(c, 'debug', 'http', 'ui requested status for unknown task')
     return c.json({ error: 'Task not found' }, 404);
@@ -576,8 +547,9 @@ app.post('/api/tasks', async (c) => {
     expectedNextInputMinutes: null,
     timestamp: Date.now(),
   }
-  tasks.set(taskId, statusUpdate)
-  broadcastStatus(taskId, statusUpdate)
+  recordTaskOwnership(userId, taskId)
+  setTaskStatus(userId, taskId, statusUpdate)
+  broadcastStatus(userId, taskId, statusUpdate)
 
   return c.json({ taskId, conversationId: createdTask.conversationId, status: 'created' })
 });
@@ -615,13 +587,25 @@ app.post('/api/orchestrator/stream-events', async (c) => {
     if (typeof cr.done === 'boolean') eventLogFields.done = cr.done
   }
   logFromContext(c, 'info', 'orchestrator-proxy', `received ${event.type} push from orchestrator; broadcasting to ui sse listeners`, eventLogFields)
+  // MT-3: orchestrator HTTP push carries only taskId — resolve the owning user
+  // via the reverse index populated at task-create time. An orphan event (owner
+  // unknown after restart, or task never registered) is logged and dropped so
+  // we don't broadcast into the wrong user's SSE slot.
+  const ownerUserId = taskId ? ownerOfTask(taskId) : undefined
+  if (!ownerUserId) {
+    logFromContext(c, 'warn', 'orchestrator-proxy', 'received orchestrator stream event for task with no recorded owner; dropping', {
+      task_id: taskId,
+      event_type: event.type,
+    })
+    return c.json({ ok: true, dropped: 'unknown task owner' });
+  }
   if (event.type === 'status') {
-    tasks.set(taskId, event.payload);
+    setTaskStatus(ownerUserId, taskId, event.payload);
   } else if (event.type === 'chat_response') {
     const { content, done } = event.payload;
-    deliverChatResponse(taskId, content, done);
+    deliverChatResponse(ownerUserId, taskId, content, done);
   }
-  broadcastStreamEvent(taskId, event);
+  broadcastStreamEvent(ownerUserId, taskId, event);
   return c.json({ ok: true });
 });
 
@@ -718,7 +702,12 @@ app.post('/api/chat', async (c) => {
   if (denied) return denied
   const { taskId, content, conversationHistory, conversationId, required_skill_domains } = body as SendMessageRequest & { required_skill_domains?: string[] };
   const traceId = c.get('traceId') as string | undefined;
-  if (taskId) c.set('taskId', taskId)
+  if (taskId) {
+    c.set('taskId', taskId)
+    // MT-3: record (taskId -> userId) so orchestrator inbound paths can resolve
+    // the owning user when delivering chat_response / status frames back.
+    recordTaskOwnership(effectiveUserId, taskId)
+  }
   if (conversationId) c.set('conversationId', conversationId)
   logFromContext(c, 'info', 'http', 'received chat message from user; queuing for orchestrator', {
     user_id: effectiveUserId,
@@ -754,7 +743,7 @@ app.post('/api/chat', async (c) => {
     timestamp: Date.now(),
   };
   if (!scheduleAutomationIntent) {
-    persistAndBroadcastStatus(workingStatus)
+    persistAndBroadcastStatus(effectiveUserId, workingStatus)
   }
 
   const encoder = new TextEncoder();
@@ -826,7 +815,7 @@ app.post('/api/chat', async (c) => {
           expectedNextInputMinutes: 0,
           timestamp: Date.now(),
         }
-        persistAndBroadcastStatus(doneStatus)
+        persistAndBroadcastStatus(effectiveUserId, doneStatus)
       }
 
       if (scheduleAutomationIntent) {
@@ -883,7 +872,8 @@ app.post('/api/chat', async (c) => {
           }
         }
 
-        const pendingKey = chatPendingKey(taskId)
+        // MT-3: parked callback is registered via task-scope, keyed by
+        // (userId, taskId) so two users can't overwrite each other's slot.
         let keepalive: ReturnType<typeof setInterval> | undefined
         const stopKeepalive = () => {
           if (keepalive !== undefined) {
@@ -894,7 +884,7 @@ app.post('/api/chat', async (c) => {
 
         const timeout = setTimeout(() => {
           stopKeepalive()
-          pendingChatResponses.delete(pendingKey)
+          dropPendingChatCallback(effectiveUserId, taskId)
           if (streamDone) return
           const msg = accumulated
             ? accumulated
@@ -910,11 +900,11 @@ app.post('/api/chat', async (c) => {
         cleanupChatStream = () => {
           stopKeepalive()
           clearTimeout(timeout)
-          pendingChatResponses.delete(pendingKey)
+          dropPendingChatCallback(effectiveUserId, taskId)
           streamDone = true
         }
 
-        pendingChatResponses.set(pendingKey, {
+        registerPendingChatCallback(effectiveUserId, taskId, {
           push(chunk: string) {
             if (streamDone) return
             accumulated += chunk
@@ -934,7 +924,7 @@ app.post('/api/chat', async (c) => {
               expectedNextInputMinutes: 0,
               timestamp: Date.now(),
             }
-            persistAndBroadcastStatus(doneStatus)
+            persistAndBroadcastStatus(effectiveUserId, doneStatus)
           },
           error(msg: string) {
             stopKeepalive()
@@ -963,7 +953,7 @@ app.post('/api/chat', async (c) => {
         }, 8_000)
         ioLog('info', 'http', 'registered chat stream as pending; awaiting orchestrator response (timeout 120s)', {
           task_id: taskId,
-          pending_key: pendingKey,
+          user_id: effectiveUserId,
         })
         return
       }
@@ -982,7 +972,7 @@ app.post('/api/chat', async (c) => {
           taskId, status: 'awaiting_feedback', lastUpdate: 'Response complete',
           expectedNextInputMinutes: 0, timestamp: Date.now(),
         }
-        persistAndBroadcastStatus(doneStatus)
+        persistAndBroadcastStatus(effectiveUserId, doneStatus)
       })()
     },
     cancel() {
@@ -1620,8 +1610,25 @@ app.post('/api/credential', async (c) => {
 // =============================================================================
 
 app.get('/api/events/:taskId', (c) => {
+  const userId = activeUserId(c)
+  if (!userId) return userIdRequired(c)
   const taskId = c.req.param('taskId');
   c.set('taskId', taskId)
+
+  // MT-3: ownership check before opening the stream. 404 — not 403 — so probing
+  // doesn't reveal whether the taskId exists for another user. The demo task
+  // (id '13', DEMO_MODE only) is the one exception: it has no real owner and
+  // is intended as a fixed-id reference stream for the mock UI.
+  const isDemoFixedTask = DEMO_MODE && taskId === '13'
+  if (!isDemoFixedTask) {
+    const owner = ownerOfTask(taskId)
+    if (!owner || owner !== userId.toLowerCase()) {
+      logFromContext(c, 'debug', 'http', 'ui requested sse for unknown or unowned task; returning 404', {
+        user_id: userId,
+      })
+      return c.json({ error: 'Task not found' }, 404)
+    }
+  }
   logFromContext(c, 'debug', 'http', 'ui opened sse connection for task event stream')
 
   const stream = new ReadableStream<Uint8Array>({
@@ -1634,19 +1641,19 @@ app.get('/api/events/:taskId', (c) => {
         }
       };
 
-      const unsubscribe = subscribeSse(taskId, push);
+      const unsubscribe = subscribeSse(userId, taskId, push);
 
       // Only push initial status when the BFF has state (e.g. after /api/chat). Otherwise the
       // web UI keeps its local mock task list without being overwritten by a synthetic default.
-      const stored = tasks.get(taskId);
+      const stored = getTaskStatus(userId, taskId);
       if (stored) {
         push(text.encode(`data: ${JSON.stringify({ type: 'status', payload: stored })}\n\n`));
       }
 
       // Demo mode: push a sample credential request for the demo task
-      if (DEMO_MODE && taskId === '13') {
+      if (isDemoFixedTask) {
         setTimeout(() => {
-          broadcastStreamEvent('13', {
+          broadcastStreamEvent(userId, '13', {
             type: 'credential_request',
             payload: DEMO_TASK_13_CREDENTIAL,
           });
@@ -1654,9 +1661,9 @@ app.get('/api/events/:taskId', (c) => {
       }
 
       const interval = setInterval(() => {
-        const current = tasks.get(taskId);
+        const current = getTaskStatus(userId, taskId);
         if (current?.status === 'working') {
-          broadcastStatus(taskId, { ...current, timestamp: Date.now() });
+          broadcastStatus(userId, taskId, { ...current, timestamp: Date.now() });
         }
       }, 2800);
 

--- a/io/api/src/index.ts
+++ b/io/api/src/index.ts
@@ -37,7 +37,7 @@ import { ioLog, logFromContext, previewHeadTail, previewWords } from './logger'
 import { startHeartbeatEmitter } from './heartbeat'
 import { mirrorMemoryConfigured, persistOrchestratorOutcomeToMemory } from './scheduled-run-mirror'
 import { messageLooksLikeUserCronScheduling } from './scheduling-language'
-import { activeUserId, userIdRequired, requireRole } from './identity'
+import { activeUserId, userIdRequired, requireRole, assertNoUserIdOverride } from './identity'
 
 // =============================================================================
 // Planner input enrichment
@@ -498,7 +498,10 @@ app.get('/api/tasks/:taskId', (c) => {
 app.post('/api/conversations', async (c) => {
   const userId = activeUserId(c)
   if (!userId) return userIdRequired(c)
-  const { title } = await c.req.json()
+  const body = await c.req.json()
+  const denied = assertNoUserIdOverride(c, body, userId)
+  if (denied) return denied
+  const { title } = body
   const conversation = await createConversation({
     userId,
     title: typeof title === 'string' ? title : undefined,
@@ -533,6 +536,8 @@ app.post('/api/tasks', async (c) => {
   const userId = activeUserId(c)
   if (!userId) return userIdRequired(c)
   const body = await c.req.json()
+  const denied = assertNoUserIdOverride(c, body, userId)
+  if (denied) return denied
   const rawConversationId = typeof body.conversationId === 'string' && body.conversationId ? body.conversationId : undefined
   const conversationId = rawConversationId && UUID_RE.test(rawConversationId) ? rawConversationId : undefined
   const title = typeof body.title === 'string' ? body.title : undefined
@@ -709,6 +714,8 @@ app.post('/api/chat', async (c) => {
   const effectiveUserId = activeUserId(c)
   if (!effectiveUserId) return userIdRequired(c)
   const body = (await c.req.json()) as SendMessageRequest;
+  const denied = assertNoUserIdOverride(c, body, effectiveUserId)
+  if (denied) return denied
   const { taskId, content, conversationHistory, conversationId, required_skill_domains } = body as SendMessageRequest & { required_skill_domains?: string[] };
   const traceId = c.get('traceId') as string | undefined;
   if (taskId) c.set('taskId', taskId)
@@ -1054,6 +1061,8 @@ app.post('/api/skills/create', async (c) => {
   if (!body || typeof body.description !== 'string' || !body.description.trim()) {
     return c.json({ error: 'description is required' }, 400)
   }
+  const denied = assertNoUserIdOverride(c, body, userId)
+  if (denied) return denied
   const scope: 'me' | 'all' = body.scope === 'all' ? 'all' : 'me'
   // Manager-gate scope=all so a regular user can't push a skill to everyone.
   if (scope === 'all') {
@@ -1095,6 +1104,8 @@ app.post('/api/skills/import-github', async (c) => {
   if (!body || typeof body.repo !== 'string' || !body.repo.trim()) {
     return c.json({ error: 'repo is required' }, 400)
   }
+  const denied = assertNoUserIdOverride(c, body, userId)
+  if (denied) return denied
   const scope: 'me' | 'all' = body.scope === 'all' ? 'all' : 'me'
   if (scope === 'all') {
     const guard = await requireRole(c, 'manager')
@@ -1304,6 +1315,8 @@ app.post('/api/users', async (c) => {
 app.delete('/api/conversations/:conversationId', async (c) => {
   const userId = activeUserId(c)
   if (!userId) return userIdRequired(c)
+  const denied = assertNoUserIdOverride(c, null, userId)
+  if (denied) return denied
   const conversationId = c.req.param('conversationId')
   c.set('conversationId', conversationId)
   logFromContext(c, 'info', 'http', 'user deleted conversation thread', { user_id: userId })
@@ -1316,6 +1329,8 @@ app.patch('/api/conversations/:conversationId', async (c) => {
   if (!userId) return userIdRequired(c)
   const conversationId = c.req.param('conversationId')
   const body = await c.req.json() as { title?: string }
+  const denied = assertNoUserIdOverride(c, body, userId)
+  if (denied) return denied
   c.set('conversationId', conversationId)
   if (body.title) {
     logFromContext(c, 'info', 'http', 'user renamed conversation thread', {
@@ -1380,6 +1395,8 @@ app.post('/api/user-crons', async (c) => {
   }
   const userId = activeUserId(c)
   if (!userId) return userIdRequired(c)
+  const denied = assertNoUserIdOverride(c, body, userId)
+  if (denied) return denied
   if (!body.name?.trim() || !body.rawInput?.trim() || !body.nextRunAt || !body.scheduleKind) {
     return c.json({ error: 'name, rawInput, nextRunAt, and scheduleKind are required' }, 400)
   }
@@ -1469,6 +1486,8 @@ app.delete('/api/user-crons/:jobId', async (c) => {
   }
   const userId = activeUserId(c)
   if (!userId) return userIdRequired(c)
+  const denied = assertNoUserIdOverride(c, null, userId)
+  if (denied) return denied
   const jobId = c.req.param('jobId')
   const res = await fetch(
     `${base}/api/v1/scheduled_jobs/${encodeURIComponent(jobId)}?userId=${encodeURIComponent(userId)}`,
@@ -1503,6 +1522,8 @@ app.post('/api/credential', async (c) => {
     keyName: string;
     value: string;
   };
+  const denied = assertNoUserIdOverride(c, body, userId)
+  if (denied) return denied
   const { taskId, requestId, keyName } = body;
   c.set('taskId', taskId)
   logFromContext(c, 'info', 'credential', 'received credential value from user; forwarding to memory vault (value not logged)', {

--- a/io/api/src/task-scope.test.ts
+++ b/io/api/src/task-scope.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import type { StatusUpdate } from '@cerberos/io-core'
+import {
+  __resetTaskScopeForTests,
+  broadcastStatus,
+  deliverChatResponse,
+  dropPendingChatCallback,
+  getTaskStatus,
+  listTasksForUser,
+  ownerOfTask,
+  persistAndBroadcastStatus,
+  recordTaskOwnership,
+  registerPendingChatCallback,
+  scopedKey,
+  setTaskStatus,
+  subscribeSse,
+} from './task-scope'
+
+const ALICE = '11111111-1111-1111-1111-111111111111'
+const BOB = '22222222-2222-2222-2222-222222222222'
+
+function status(taskId: string, lastUpdate = 'working'): StatusUpdate {
+  return {
+    taskId,
+    status: 'working',
+    lastUpdate,
+    expectedNextInputMinutes: null,
+    timestamp: 1700000000000,
+  }
+}
+
+afterEach(() => {
+  __resetTaskScopeForTests()
+})
+
+describe('scopedKey — composite (userId, taskId) format', () => {
+  test('lowercases both halves', () => {
+    expect(scopedKey(ALICE.toUpperCase(), 'TASK-13')).toBe(`${ALICE}:task-13`)
+  })
+
+  test('trims surrounding whitespace', () => {
+    expect(scopedKey(`  ${ALICE}  `, '  t-1  ')).toBe(`${ALICE}:t-1`)
+  })
+
+  test('different users with same taskId produce different keys', () => {
+    expect(scopedKey(ALICE, 'shared-id')).not.toBe(scopedKey(BOB, 'shared-id'))
+  })
+})
+
+describe('taskOwnership reverse index', () => {
+  test('recordTaskOwnership / ownerOfTask round-trip', () => {
+    recordTaskOwnership(ALICE, 'task-13')
+    expect(ownerOfTask('task-13')).toBe(ALICE)
+  })
+
+  test('ownerOfTask is case-insensitive on the taskId', () => {
+    recordTaskOwnership(ALICE, 'Task-13')
+    expect(ownerOfTask('TASK-13')).toBe(ALICE)
+  })
+
+  test('unknown task returns undefined (not a fallback owner)', () => {
+    expect(ownerOfTask('never-registered')).toBeUndefined()
+  })
+
+  test('re-registering with a different user overwrites — last writer wins', () => {
+    recordTaskOwnership(ALICE, 'task-x')
+    recordTaskOwnership(BOB, 'task-x')
+    expect(ownerOfTask('task-x')).toBe(BOB)
+  })
+})
+
+describe('tasks map — per-user isolation', () => {
+  test('setTaskStatus then getTaskStatus round-trips for the owner only', () => {
+    setTaskStatus(ALICE, 't-1', status('t-1'))
+    expect(getTaskStatus(ALICE, 't-1')).toBeDefined()
+    expect(getTaskStatus(BOB, 't-1')).toBeUndefined()
+  })
+
+  test('two users with identical taskIds do NOT collide', () => {
+    setTaskStatus(ALICE, 'same-id', status('same-id', 'alice-update'))
+    setTaskStatus(BOB, 'same-id', status('same-id', 'bob-update'))
+    expect(getTaskStatus(ALICE, 'same-id')?.lastUpdate).toBe('alice-update')
+    expect(getTaskStatus(BOB, 'same-id')?.lastUpdate).toBe('bob-update')
+  })
+
+  test('listTasksForUser returns only that user\'s tasks', () => {
+    setTaskStatus(ALICE, 'a-1', status('a-1'))
+    setTaskStatus(ALICE, 'a-2', status('a-2'))
+    setTaskStatus(BOB, 'b-1', status('b-1'))
+    const aliceList = listTasksForUser(ALICE)
+    expect(aliceList).toHaveLength(2)
+    expect(aliceList.every((t) => t.taskId.startsWith('a-'))).toBe(true)
+  })
+
+  test('listTasksForUser does NOT leak across users sharing taskId prefix', () => {
+    setTaskStatus(ALICE, 'shared', status('shared'))
+    setTaskStatus(BOB, 'shared', status('shared', 'bob-version'))
+    const bobList = listTasksForUser(BOB)
+    expect(bobList).toHaveLength(1)
+    expect(bobList[0].lastUpdate).toBe('bob-version')
+  })
+})
+
+describe('SSE subscribers — per-user isolation', () => {
+  test('broadcast to user A does not reach user B subscribing to the same taskId', () => {
+    const aReceived: Uint8Array[] = []
+    const bReceived: Uint8Array[] = []
+    const unA = subscribeSse(ALICE, 'shared', (b) => { aReceived.push(b) })
+    const unB = subscribeSse(BOB, 'shared', (b) => { bReceived.push(b) })
+
+    broadcastStatus(ALICE, 'shared', status('shared'))
+
+    expect(aReceived.length).toBe(1)
+    expect(bReceived.length).toBe(0)
+    unA()
+    unB()
+  })
+
+  test('unsubscribe cleans up the per-(userId, taskId) slot', () => {
+    const seen: Uint8Array[] = []
+    const unsubscribe = subscribeSse(ALICE, 't-1', (b) => { seen.push(b) })
+    unsubscribe()
+    broadcastStatus(ALICE, 't-1', status('t-1'))
+    expect(seen.length).toBe(0)
+  })
+})
+
+describe('pendingChatResponses — per-user isolation', () => {
+  test('deliverChatResponse(A, taskId) only fires the callback registered under A', () => {
+    let aCalls = 0
+    let bCalls = 0
+    registerPendingChatCallback(ALICE, 'shared', {
+      push: () => { aCalls += 1 },
+      complete: () => {},
+      error: () => {},
+    })
+    registerPendingChatCallback(BOB, 'shared', {
+      push: () => { bCalls += 1 },
+      complete: () => {},
+      error: () => {},
+    })
+
+    deliverChatResponse(ALICE, 'shared', 'hi', false)
+
+    expect(aCalls).toBe(1)
+    expect(bCalls).toBe(0)
+  })
+
+  test('done=true removes the callback so subsequent deliveries are dropped', () => {
+    let calls = 0
+    let completed = false
+    registerPendingChatCallback(ALICE, 't-1', {
+      push: () => { calls += 1 },
+      complete: () => { completed = true },
+      error: () => {},
+    })
+
+    expect(deliverChatResponse(ALICE, 't-1', 'final', true)).toBe(true)
+    expect(completed).toBe(true)
+    expect(deliverChatResponse(ALICE, 't-1', 'late', false)).toBe(false)
+    expect(calls).toBe(1)
+  })
+
+  test('dropPendingChatCallback evicts under the composite key, not by taskId', () => {
+    registerPendingChatCallback(ALICE, 'shared', {
+      push: () => {}, complete: () => {}, error: () => {},
+    })
+    registerPendingChatCallback(BOB, 'shared', {
+      push: () => {}, complete: () => {}, error: () => {},
+    })
+
+    dropPendingChatCallback(ALICE, 'shared')
+
+    expect(deliverChatResponse(ALICE, 'shared', 'x', false)).toBe(false)
+    expect(deliverChatResponse(BOB, 'shared', 'x', false)).toBe(true)
+  })
+})
+
+describe('persistAndBroadcastStatus — writes and broadcasts under the owner\'s slot', () => {
+  test('after persist, only owner\'s getTaskStatus and SSE subscriber see the update', () => {
+    const aReceived: Uint8Array[] = []
+    const bReceived: Uint8Array[] = []
+    subscribeSse(ALICE, 'cross-user', (b) => { aReceived.push(b) })
+    subscribeSse(BOB, 'cross-user', (b) => { bReceived.push(b) })
+
+    persistAndBroadcastStatus(ALICE, status('cross-user'))
+
+    expect(getTaskStatus(ALICE, 'cross-user')).toBeDefined()
+    expect(getTaskStatus(BOB, 'cross-user')).toBeUndefined()
+    expect(aReceived.length).toBe(1)
+    expect(bReceived.length).toBe(0)
+  })
+})
+
+describe('MT-3 attacker scenario: guess-the-taskId across users', () => {
+  test('Bob registers task-13; Alice cannot peek at it via getTaskStatus', () => {
+    recordTaskOwnership(BOB, 'task-13')
+    setTaskStatus(BOB, 'task-13', status('task-13', 'bob private'))
+    // Alice has the same taskId in her head (e.g. saw it in logs) and asks IO
+    expect(getTaskStatus(ALICE, 'task-13')).toBeUndefined()
+    // Reverse index still tells the server who owns it (for orchestrator routing)
+    // but Alice can't claim it just by setting X-Active-User to herself.
+    expect(ownerOfTask('task-13')).toBe(BOB)
+  })
+
+  test('Bob has a parked chat stream; Alice cannot intercept the orchestrator reply', () => {
+    const bobChunks: string[] = []
+    recordTaskOwnership(BOB, 'task-13')
+    registerPendingChatCallback(BOB, 'task-13', {
+      push: (c) => { bobChunks.push(c) },
+      complete: () => {},
+      error: () => {},
+    })
+
+    // Simulated attacker: Alice tries to drain Bob's slot using her own userId
+    expect(deliverChatResponse(ALICE, 'task-13', 'malicious', false)).toBe(false)
+    expect(bobChunks.length).toBe(0)
+
+    // Owner-resolved delivery (what the orchestrator inbound path actually does) works
+    const owner = ownerOfTask('task-13')!
+    expect(deliverChatResponse(owner, 'task-13', 'real reply', false)).toBe(true)
+    expect(bobChunks).toEqual(['real reply'])
+  })
+})

--- a/io/api/src/task-scope.ts
+++ b/io/api/src/task-scope.ts
@@ -1,0 +1,159 @@
+/**
+ * MT-3: per-task in-memory state, scoped by (userId, taskId).
+ *
+ * The IO API server holds short-term state for each in-flight task in three
+ * Maps: latest status (`tasks`), parked chat-stream callbacks
+ * (`pendingChatResponses`), and SSE subscribers (`sseClients`). Pre-MT-3 all
+ * three were keyed by `taskId` alone, which let two users collide on a short
+ * id and let an attacker tap another user's stream by guessing the id.
+ *
+ * This module owns those maps, exposes only the composite-key APIs, and is
+ * side-effect-free so tests can import it without spinning up NATS or the
+ * HTTP listener.
+ *
+ * Orchestrator inbound paths (NATS callback, /api/orchestrator/stream-events)
+ * carry only `taskId`, so we also keep a `taskOwnership` reverse index
+ * populated when a task is registered. Unknown-owner events are dropped at
+ * the call site — the caller logs and skips broadcast rather than guessing.
+ */
+
+import type { OrchestratorStreamEvent, StatusUpdate } from '@cerberos/io-core'
+
+export type SsePush = (bytes: Uint8Array) => void
+
+export type ChatResponseCallback = {
+  push: (content: string) => void
+  complete: () => void
+  error: (msg: string) => void
+}
+
+/** Canonical taskId form — uppercase UUIDs and stray whitespace must collapse. */
+export function chatPendingKey(taskId: string): string {
+  return taskId.trim().toLowerCase()
+}
+
+/** Composite key for per-task state. Format: `<userId>:<taskId>` (both lowercased). */
+export function scopedKey(userId: string, taskId: string): string {
+  return `${userId.trim().toLowerCase()}:${chatPendingKey(taskId)}`
+}
+
+const taskOwnership = new Map<string, string>()
+const tasks = new Map<string, StatusUpdate>()
+const sseClients = new Map<string, Set<SsePush>>()
+const pendingChatResponses = new Map<string, ChatResponseCallback>()
+
+const text = new TextEncoder()
+
+export function recordTaskOwnership(userId: string, taskId: string): void {
+  taskOwnership.set(chatPendingKey(taskId), userId.trim().toLowerCase())
+}
+
+export function ownerOfTask(taskId: string): string | undefined {
+  return taskOwnership.get(chatPendingKey(taskId))
+}
+
+export function getTaskStatus(userId: string, taskId: string): StatusUpdate | undefined {
+  return tasks.get(scopedKey(userId, taskId))
+}
+
+export function setTaskStatus(userId: string, taskId: string, status: StatusUpdate): void {
+  tasks.set(scopedKey(userId, taskId), status)
+}
+
+export function listTasksForUser(userId: string): StatusUpdate[] {
+  const prefix = `${userId.trim().toLowerCase()}:`
+  const out: StatusUpdate[] = []
+  for (const [key, value] of tasks) {
+    if (key.startsWith(prefix)) out.push(value)
+  }
+  return out
+}
+
+export function registerPendingChatCallback(
+  userId: string,
+  taskId: string,
+  cb: ChatResponseCallback,
+): void {
+  pendingChatResponses.set(scopedKey(userId, taskId), cb)
+}
+
+export function dropPendingChatCallback(userId: string, taskId: string): void {
+  pendingChatResponses.delete(scopedKey(userId, taskId))
+}
+
+export function deliverChatResponse(
+  userId: string,
+  taskId: string,
+  content: string,
+  done: boolean,
+): boolean {
+  const key = scopedKey(userId, taskId)
+  const cb = pendingChatResponses.get(key)
+  if (!cb) return false
+  cb.push(content)
+  if (done) {
+    cb.complete()
+    pendingChatResponses.delete(key)
+  }
+  return true
+}
+
+export function failPendingChatCallback(userId: string, taskId: string, msg: string): boolean {
+  const key = scopedKey(userId, taskId)
+  const cb = pendingChatResponses.get(key)
+  if (!cb) return false
+  cb.error(msg)
+  pendingChatResponses.delete(key)
+  return true
+}
+
+export function subscribeSse(userId: string, taskId: string, push: SsePush): () => void {
+  const key = scopedKey(userId, taskId)
+  let set = sseClients.get(key)
+  if (!set) {
+    set = new Set()
+    sseClients.set(key, set)
+  }
+  set.add(push)
+  return () => {
+    set!.delete(push)
+    if (set!.size === 0) sseClients.delete(key)
+  }
+}
+
+export function broadcastStreamEvent(
+  userId: string,
+  taskId: string,
+  event: OrchestratorStreamEvent,
+): void {
+  const set = sseClients.get(scopedKey(userId, taskId))
+  if (!set) return
+  const bytes = text.encode(`data: ${JSON.stringify(event)}\n\n`)
+  for (const push of set) {
+    try {
+      push(bytes)
+    } catch {
+      /* client disconnected */
+    }
+  }
+}
+
+export function broadcastStatus(userId: string, taskId: string, status: StatusUpdate): void {
+  broadcastStreamEvent(userId, taskId, { type: 'status', payload: status })
+}
+
+export function persistAndBroadcastStatus(userId: string, status: StatusUpdate): void {
+  setTaskStatus(userId, status.taskId, status)
+  broadcastStatus(userId, status.taskId, status)
+}
+
+/**
+ * Test-only hook. Wipes every map. Not exported through any production path;
+ * `index.ts` never calls it. Keeps test isolation cheap.
+ */
+export function __resetTaskScopeForTests(): void {
+  taskOwnership.clear()
+  tasks.clear()
+  sseClients.clear()
+  pendingChatResponses.clear()
+}


### PR DESCRIPTION
## Summary
This PR now carries **two stacked changes** (MT-3 was merged into the MT-2 base branch on 2026-05-11):

### MT-2 — hard-reject body/query userId override (commit \`0264c18\`)
- Adds \`assertNoUserIdOverride(c, body, activeId)\` to \`io/api/src/identity.ts\`. Returns 403 when \`body.userId\` or \`?userId\` differs from \`X-Active-User\`; silently accepts a matching value (back-compat).
- Wires the guard into every user-scoped write endpoint: \`POST /api/{conversations, tasks, chat, skills/create, skills/import-github, user-crons, credential}\`, \`PATCH/DELETE /api/conversations/:id\`, \`DELETE /api/user-crons/:jobId\`.
- 10 new unit tests covering the attacker scenario, query-string variant, case/whitespace handling, null body, and non-string \`userId\` rejection.

### MT-3 — re-key in-process task state by (userId, taskId) (commit \`baff51b\`, merge \`8acd283\`)
- Extracts the three in-process Maps (\`tasks\`, \`pendingChatResponses\`, \`sseClients\`) plus a new \`taskOwnership\` reverse index into a side-effect-free \`io/api/src/task-scope.ts\`. All keys are \`scopedKey(userId, taskId)\`.
- Threads \`userId\` through every call site in \`index.ts\`. \`POST /api/tasks\` and \`POST /api/chat\` call \`recordTaskOwnership\` so orchestrator inbound paths (NATS subscriber + \`POST /api/orchestrator/stream-events\`) resolve the owning user from a task-id-only payload. Orphan events are logged and dropped.
- Closes the cross-user leaks in \`GET /api/tasks\`, \`GET /api/tasks/:taskId\`, and \`GET /api/events/:taskId\`. The SSE endpoint **404s** (not 403s) on miss so probing can't reveal whether another user owns the id. The \`DEMO_MODE\` fixed task id \`'13'\` remains accessible for the mock UI.
- 19 new unit tests (\`task-scope.test.ts\`) covering the \`scopedKey\` format, ownership reverse index, per-user isolation across all three maps, identical-taskId-across-users non-collision, and both MT-3 attacker scenarios.

## Acceptance criteria
**MT-2 (#183):**
- [x] All write endpoints derive \`user_id\` from \`activeUserId(c)\` only
- [x] If body/query supplies a \`userId\` that differs from active user → 403
- [x] If body/query supplies a matching \`userId\` → silently ignore
- [x] Test: \`body.userId=<victim>\` + \`X-Active-User=<attacker>\` returns 403

**MT-3 (#184):**
- [x] All three maps re-keyed by \`\${userId}:\${taskId}\`
- [x] \`/api/events/:taskId\` looks up by \`(activeUserId, taskId)\` — 404 if not owned
- [x] Cleanup paths (timeouts, disconnects, completion, error) updated
- [x] Test: user A subscribes to user B's taskId → returns nothing

## Test plan
- [x] \`bun test src\` in \`io/api\` — **49 pass / 0 fail** (22 in \`identity.test.ts\`, 19 in \`task-scope.test.ts\`, plus pre-existing scheduling-language and trace-context tests)
- [x] \`bunx tsc --noEmit\` — **29 errors on main, 29 errors on this branch** (all pre-existing missing-\`@types/node\` noise, none in the touched files)
- [ ] Manual: \`POST /api/tasks\` with \`X-Active-User: <A>\` + \`body.userId: <B>\` → expect 403
- [ ] Manual: user A creates task; user B's \`GET /api/events/<A_taskId>\` with their own \`X-Active-User\` → expect 404
- [ ] Manual: orchestrator response for a known task still streams to the original \`/api/chat\` caller (taskOwnership reverse index)

Closes #183. Closes #184. Umbrella: #178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)