### PR TITLE
fix(mt-4): scope orchestrator_records to user_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ context/
 
 # Implementation plans (private, not pushed)
 plans/
+plans/mt-4-orchestrator-records-user-id.md
 
 # OS / filesystem
 .DS_Store

--- a/memory/internal/api/orchestrator_handler.go
+++ b/memory/internal/api/orchestrator_handler.go
@@ -18,6 +18,7 @@ type OrchestratorHandler struct {
 }
 
 type WriteOrchestratorRecordRequest struct {
+	UserID              string          `json:"user_id"`
 	OrchestratorTaskRef string          `json:"orchestrator_task_ref"`
 	TaskID              string          `json:"task_id"`
 	PlanID              string          `json:"plan_id,omitempty"`
@@ -31,6 +32,7 @@ type WriteOrchestratorRecordRequest struct {
 
 type OrchestratorRecordResponse struct {
 	ID                  string      `json:"id,omitempty"`
+	UserID              string      `json:"user_id"`
 	OrchestratorTaskRef string      `json:"orchestrator_task_ref"`
 	TaskID              string      `json:"task_id"`
 	PlanID              *string     `json:"plan_id,omitempty"`
@@ -64,8 +66,8 @@ func (h *OrchestratorHandler) HandleWriteRecord(w http.ResponseWriter, r *http.R
 		writeJSONError(w, http.StatusBadRequest, "invalid_argument", "invalid request body", nil)
 		return
 	}
-	if stringsBlank(req.OrchestratorTaskRef) || stringsBlank(req.TaskID) || stringsBlank(req.DataType) || stringsBlank(req.Timestamp) || len(req.Payload) == 0 {
-		writeJSONError(w, http.StatusBadRequest, "invalid_argument", "orchestrator_task_ref, task_id, data_type, timestamp, and payload are required", nil)
+	if stringsBlank(req.UserID) || stringsBlank(req.OrchestratorTaskRef) || stringsBlank(req.TaskID) || stringsBlank(req.DataType) || stringsBlank(req.Timestamp) || len(req.Payload) == 0 {
+		writeJSONError(w, http.StatusBadRequest, "invalid_argument", "user_id, orchestrator_task_ref, task_id, data_type, timestamp, and payload are required", nil)
 		return
 	}
 	if len(req.Payload) > maxOrchestratorPayloadBytes {
@@ -83,6 +85,7 @@ func (h *OrchestratorHandler) HandleWriteRecord(w http.ResponseWriter, r *http.R
 	}
 
 	record, err := h.repo.WriteRecord(r.Context(), storage.WriteOrchestratorRecordParams{
+		UserID:              req.UserID,
 		OrchestratorTaskRef: req.OrchestratorTaskRef,
 		TaskID:              req.TaskID,
 		PlanID:              req.PlanID,
@@ -97,7 +100,8 @@ func (h *OrchestratorHandler) HandleWriteRecord(w http.ResponseWriter, r *http.R
 		switch {
 		case errors.Is(err, storage.ErrUnknownOrchestratorDataType),
 			errors.Is(err, storage.ErrMissingPlanID),
-			errors.Is(err, storage.ErrMissingSubtaskID):
+			errors.Is(err, storage.ErrMissingSubtaskID),
+			errors.Is(err, storage.ErrMissingUserID):
 			writeJSONError(w, http.StatusBadRequest, "invalid_argument", err.Error(), nil)
 		default:
 			writeJSONError(w, http.StatusInternalServerError, "internal", "failed to write orchestrator record", err.Error())
@@ -129,10 +133,15 @@ func (h *OrchestratorHandler) HandleWriteRecord(w http.ResponseWriter, r *http.R
 // @Failure 500 {object} map[string]interface{} "Internal Server Error"
 // @Router /api/v1/orchestrator/records [get]
 func (h *OrchestratorHandler) HandleQueryRecords(w http.ResponseWriter, r *http.Request) {
+	userID := r.URL.Query().Get("user_id")
 	dataType := r.URL.Query().Get("data_type")
 	taskID := r.URL.Query().Get("task_id")
 	orchRef := r.URL.Query().Get("orchestrator_task_ref")
 	stateFilter := r.URL.Query().Get("state_filter")
+	if stringsBlank(userID) {
+		writeJSONError(w, http.StatusBadRequest, "invalid_argument", "user_id is required", nil)
+		return
+	}
 	if stringsBlank(dataType) {
 		writeJSONError(w, http.StatusBadRequest, "invalid_argument", "data_type is required", nil)
 		return
@@ -170,6 +179,7 @@ func (h *OrchestratorHandler) HandleQueryRecords(w http.ResponseWriter, r *http.
 	}
 
 	records, err := h.repo.QueryRecords(r.Context(), storage.QueryOrchestratorRecordsParams{
+		UserID:              userID,
 		DataType:            dataType,
 		TaskID:              taskID,
 		OrchestratorTaskRef: orchRef,
@@ -178,8 +188,12 @@ func (h *OrchestratorHandler) HandleQueryRecords(w http.ResponseWriter, r *http.
 		StateFilter:         stateFilter,
 	})
 	if err != nil {
-		if errors.Is(err, storage.ErrUnknownOrchestratorDataType) {
+		switch {
+		case errors.Is(err, storage.ErrUnknownOrchestratorDataType):
 			writeJSONError(w, http.StatusBadRequest, "invalid_argument", "invalid data_type", nil)
+			return
+		case errors.Is(err, storage.ErrMissingUserID):
+			writeJSONError(w, http.StatusBadRequest, "invalid_argument", err.Error(), nil)
 			return
 		}
 		writeJSONError(w, http.StatusInternalServerError, "internal", "failed to query orchestrator records", err.Error())
@@ -208,10 +222,11 @@ func (h *OrchestratorHandler) HandleQueryRecords(w http.ResponseWriter, r *http.
 // @Failure 500 {object} map[string]interface{} "Internal Server Error"
 // @Router /api/v1/orchestrator/records/latest [get]
 func (h *OrchestratorHandler) HandleReadLatest(w http.ResponseWriter, r *http.Request) {
+	userID := r.URL.Query().Get("user_id")
 	taskID := r.URL.Query().Get("task_id")
 	dataType := r.URL.Query().Get("data_type")
-	if stringsBlank(taskID) || stringsBlank(dataType) {
-		writeJSONError(w, http.StatusBadRequest, "invalid_argument", "task_id and data_type are required", nil)
+	if stringsBlank(userID) || stringsBlank(taskID) || stringsBlank(dataType) {
+		writeJSONError(w, http.StatusBadRequest, "invalid_argument", "user_id, task_id and data_type are required", nil)
 		return
 	}
 	if !storage.ValidOrchestratorDataType(dataType) {
@@ -219,11 +234,12 @@ func (h *OrchestratorHandler) HandleReadLatest(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	record, err := h.repo.ReadLatest(r.Context(), taskID, dataType)
+	record, err := h.repo.ReadLatest(r.Context(), userID, taskID, dataType)
 	if err != nil {
 		switch {
-		case errors.Is(err, storage.ErrUnknownOrchestratorDataType):
-			writeJSONError(w, http.StatusBadRequest, "invalid_argument", "invalid data_type", nil)
+		case errors.Is(err, storage.ErrUnknownOrchestratorDataType),
+			errors.Is(err, storage.ErrMissingUserID):
+			writeJSONError(w, http.StatusBadRequest, "invalid_argument", err.Error(), nil)
 		case errors.Is(err, storage.ErrOrchestratorRecordNotFound):
 			writeJSONError(w, http.StatusNotFound, "not_found", "record not found", nil)
 		default:
@@ -255,6 +271,7 @@ func orchestratorRecordResponse(rec storage.OrchestratorRecord, includeID bool) 
 		traceID = &v
 	}
 	resp := OrchestratorRecordResponse{
+		UserID:              uuid.UUID(rec.UserID.Bytes).String(),
 		OrchestratorTaskRef: rec.OrchestratorTaskRef,
 		TaskID:              rec.TaskID,
 		PlanID:              planID,

--- a/memory/internal/storage/orchestrator_repository.go
+++ b/memory/internal/storage/orchestrator_repository.go
@@ -18,6 +18,7 @@ var (
 	ErrMissingPlanID               = errors.New("plan_id is required for this data_type")
 	ErrMissingSubtaskID            = errors.New("subtask_id is required for this data_type")
 	ErrOrchestratorRecordNotFound  = errors.New("orchestrator record not found")
+	ErrMissingUserID               = errors.New("user_id is required")
 )
 
 var (
@@ -48,6 +49,7 @@ type OrchestratorRepository struct {
 
 type OrchestratorRecord struct {
 	ID                  pgtype.UUID        `json:"id"`
+	UserID              pgtype.UUID        `json:"user_id"`
 	OrchestratorTaskRef string             `json:"orchestrator_task_ref"`
 	TaskID              string             `json:"task_id"`
 	PlanID              pgtype.Text        `json:"plan_id"`
@@ -61,6 +63,7 @@ type OrchestratorRecord struct {
 }
 
 type WriteOrchestratorRecordParams struct {
+	UserID              string
 	OrchestratorTaskRef string
 	TaskID              string
 	PlanID              string
@@ -73,6 +76,7 @@ type WriteOrchestratorRecordParams struct {
 }
 
 type QueryOrchestratorRecordsParams struct {
+	UserID              string
 	DataType            string
 	TaskID              string
 	OrchestratorTaskRef string
@@ -97,10 +101,18 @@ func ValidOrchestratorDataType(dataType string) bool {
 func (r *OrchestratorRepository) EnsureSchema(ctx context.Context) error {
 	statements := []string{
 		`CREATE SCHEMA IF NOT EXISTS orchestrator_schema;`,
+		// MT-4 (#185): dev-DB wipe so the new NOT NULL user_id column can be added
+		// without a row-by-row backfill. AC explicitly permits this for dev/demo.
+		// Wrapped to no-op on a fresh database where the table doesn't exist yet.
+		`DO $$ BEGIN
+    TRUNCATE TABLE orchestrator_schema.orchestrator_records;
+EXCEPTION WHEN undefined_table THEN NULL;
+END $$;`,
 		`CREATE TABLE IF NOT EXISTS orchestrator_schema.orchestrator_records (
     id UUID PRIMARY KEY,
     orchestrator_task_ref TEXT NOT NULL,
     task_id TEXT NOT NULL,
+    user_id UUID NOT NULL REFERENCES identity_schema.users(id),
     plan_id TEXT,
     subtask_id TEXT,
     trace_id VARCHAR(64),
@@ -110,20 +122,26 @@ func (r *OrchestratorRepository) EnsureSchema(ctx context.Context) error {
     ttl_seconds INT NOT NULL DEFAULT 0,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );`,
-		`CREATE INDEX IF NOT EXISTS idx_orch_records_task_id_type
-    ON orchestrator_schema.orchestrator_records (task_id, data_type, timestamp DESC);`,
-		`CREATE INDEX IF NOT EXISTS idx_orch_records_orch_ref_type
-    ON orchestrator_schema.orchestrator_records (orchestrator_task_ref, data_type, timestamp DESC);`,
-		`CREATE INDEX IF NOT EXISTS idx_orch_records_type_timestamp
-    ON orchestrator_schema.orchestrator_records (data_type, timestamp DESC);`,
+		// Drop pre-MT-4 indexes that lacked user_id leading column.
+		`DROP INDEX IF EXISTS orchestrator_schema.idx_orch_records_task_id_type;`,
+		`DROP INDEX IF EXISTS orchestrator_schema.idx_orch_records_orch_ref_type;`,
+		`DROP INDEX IF EXISTS orchestrator_schema.idx_orch_records_type_timestamp;`,
+		`CREATE INDEX IF NOT EXISTS idx_orch_records_user_task
+    ON orchestrator_schema.orchestrator_records (user_id, task_id);`,
+		`CREATE INDEX IF NOT EXISTS idx_orch_records_user_task_type
+    ON orchestrator_schema.orchestrator_records (user_id, task_id, data_type, timestamp DESC);`,
+		`CREATE INDEX IF NOT EXISTS idx_orch_records_user_orch_ref_type
+    ON orchestrator_schema.orchestrator_records (user_id, orchestrator_task_ref, data_type, timestamp DESC);`,
+		`CREATE INDEX IF NOT EXISTS idx_orch_records_user_type_timestamp
+    ON orchestrator_schema.orchestrator_records (user_id, data_type, timestamp DESC);`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_orch_records_task_state_upsert
-    ON orchestrator_schema.orchestrator_records (task_id, data_type)
+    ON orchestrator_schema.orchestrator_records (user_id, task_id, data_type)
     WHERE data_type = 'task_state';`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_orch_records_plan_state_upsert
-    ON orchestrator_schema.orchestrator_records (task_id, plan_id, data_type)
+    ON orchestrator_schema.orchestrator_records (user_id, task_id, plan_id, data_type)
     WHERE data_type = 'plan_state';`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_orch_records_subtask_state_upsert
-    ON orchestrator_schema.orchestrator_records (task_id, subtask_id, data_type)
+    ON orchestrator_schema.orchestrator_records (user_id, task_id, subtask_id, data_type)
     WHERE data_type = 'subtask_state';`,
 		`CREATE OR REPLACE FUNCTION orchestrator_schema.reject_append_only_mutation()
 RETURNS trigger AS $$
@@ -155,6 +173,9 @@ $$ LANGUAGE plpgsql;`,
 }
 
 func (r *OrchestratorRepository) WriteRecord(ctx context.Context, params WriteOrchestratorRecordParams) (OrchestratorRecord, error) {
+	if isBlank(params.UserID) {
+		return OrchestratorRecord{}, ErrMissingUserID
+	}
 	if !ValidOrchestratorDataType(params.DataType) {
 		return OrchestratorRecord{}, ErrUnknownOrchestratorDataType
 	}
@@ -181,12 +202,17 @@ func (r *OrchestratorRepository) insertRecord(ctx context.Context, params WriteO
 	if err != nil {
 		return OrchestratorRecord{}, err
 	}
+	userUUID, err := parseUUID(params.UserID)
+	if err != nil {
+		return OrchestratorRecord{}, fmt.Errorf("user_id: %w", err)
+	}
 	row := r.pool.QueryRow(ctx, `
 INSERT INTO orchestrator_schema.orchestrator_records (
-    id, orchestrator_task_ref, task_id, plan_id, subtask_id, trace_id, data_type, timestamp, payload, ttl_seconds, created_at
-) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,NOW())
-RETURNING id, orchestrator_task_ref, task_id, plan_id, subtask_id, trace_id, data_type, timestamp, payload, ttl_seconds, created_at`,
+    id, user_id, orchestrator_task_ref, task_id, plan_id, subtask_id, trace_id, data_type, timestamp, payload, ttl_seconds, created_at
+) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,NOW())
+RETURNING id, user_id, orchestrator_task_ref, task_id, plan_id, subtask_id, trace_id, data_type, timestamp, payload, ttl_seconds, created_at`,
 		pgtype.UUID{Bytes: recordID, Valid: true},
+		userUUID,
 		params.OrchestratorTaskRef,
 		params.TaskID,
 		textValue(params.PlanID),
@@ -207,24 +233,29 @@ func (r *OrchestratorRepository) upsertRecord(ctx context.Context, params WriteO
 	}
 	defer tx.Rollback(ctx)
 
+	userUUID, err := parseUUID(params.UserID)
+	if err != nil {
+		return OrchestratorRecord{}, fmt.Errorf("user_id: %w", err)
+	}
+
 	var deleteSQL string
 	var deleteArgs []any
 	switch params.DataType {
 	case "task_state":
 		deleteSQL = `
 DELETE FROM orchestrator_schema.orchestrator_records
-WHERE task_id = $1 AND data_type = $2`
-		deleteArgs = []any{params.TaskID, params.DataType}
+WHERE user_id = $1 AND task_id = $2 AND data_type = $3`
+		deleteArgs = []any{userUUID, params.TaskID, params.DataType}
 	case "plan_state":
 		deleteSQL = `
 DELETE FROM orchestrator_schema.orchestrator_records
-WHERE task_id = $1 AND plan_id = $2 AND data_type = $3`
-		deleteArgs = []any{params.TaskID, params.PlanID, params.DataType}
+WHERE user_id = $1 AND task_id = $2 AND plan_id = $3 AND data_type = $4`
+		deleteArgs = []any{userUUID, params.TaskID, params.PlanID, params.DataType}
 	case "subtask_state":
 		deleteSQL = `
 DELETE FROM orchestrator_schema.orchestrator_records
-WHERE task_id = $1 AND plan_id = $2 AND subtask_id = $3 AND data_type = $4`
-		deleteArgs = []any{params.TaskID, params.PlanID, params.SubtaskID, params.DataType}
+WHERE user_id = $1 AND task_id = $2 AND plan_id = $3 AND subtask_id = $4 AND data_type = $5`
+		deleteArgs = []any{userUUID, params.TaskID, params.PlanID, params.SubtaskID, params.DataType}
 	default:
 		return OrchestratorRecord{}, ErrUnknownOrchestratorDataType
 	}
@@ -239,10 +270,11 @@ WHERE task_id = $1 AND plan_id = $2 AND subtask_id = $3 AND data_type = $4`
 	}
 	insertRow := tx.QueryRow(ctx, `
 INSERT INTO orchestrator_schema.orchestrator_records (
-    id, orchestrator_task_ref, task_id, plan_id, subtask_id, trace_id, data_type, timestamp, payload, ttl_seconds, created_at
-) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,NOW())
-RETURNING id, orchestrator_task_ref, task_id, plan_id, subtask_id, trace_id, data_type, timestamp, payload, ttl_seconds, created_at`,
+    id, user_id, orchestrator_task_ref, task_id, plan_id, subtask_id, trace_id, data_type, timestamp, payload, ttl_seconds, created_at
+) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,NOW())
+RETURNING id, user_id, orchestrator_task_ref, task_id, plan_id, subtask_id, trace_id, data_type, timestamp, payload, ttl_seconds, created_at`,
 		pgtype.UUID{Bytes: recordID, Valid: true},
+		userUUID,
 		params.OrchestratorTaskRef,
 		params.TaskID,
 		textValue(params.PlanID),
@@ -264,15 +296,22 @@ RETURNING id, orchestrator_task_ref, task_id, plan_id, subtask_id, trace_id, dat
 }
 
 func (r *OrchestratorRepository) QueryRecords(ctx context.Context, params QueryOrchestratorRecordsParams) ([]OrchestratorRecord, error) {
+	if isBlank(params.UserID) {
+		return nil, ErrMissingUserID
+	}
 	if !ValidOrchestratorDataType(params.DataType) {
 		return nil, ErrUnknownOrchestratorDataType
 	}
+	userUUID, err := parseUUID(params.UserID)
+	if err != nil {
+		return nil, fmt.Errorf("user_id: %w", err)
+	}
 
-	args := []any{params.DataType}
+	args := []any{userUUID, params.DataType}
 	q := `
-SELECT id, orchestrator_task_ref, task_id, plan_id, subtask_id, trace_id, data_type, timestamp, payload, ttl_seconds, created_at
+SELECT id, user_id, orchestrator_task_ref, task_id, plan_id, subtask_id, trace_id, data_type, timestamp, payload, ttl_seconds, created_at
 FROM orchestrator_schema.orchestrator_records
-WHERE data_type = $1`
+WHERE user_id = $1 AND data_type = $2`
 
 	if params.TaskID != "" {
 		args = append(args, params.TaskID)
@@ -315,16 +354,23 @@ WHERE data_type = $1`
 	return out, nil
 }
 
-func (r *OrchestratorRepository) ReadLatest(ctx context.Context, taskID, dataType string) (OrchestratorRecord, error) {
+func (r *OrchestratorRepository) ReadLatest(ctx context.Context, userID, taskID, dataType string) (OrchestratorRecord, error) {
+	if isBlank(userID) {
+		return OrchestratorRecord{}, ErrMissingUserID
+	}
 	if !ValidOrchestratorDataType(dataType) {
 		return OrchestratorRecord{}, ErrUnknownOrchestratorDataType
 	}
+	userUUID, err := parseUUID(userID)
+	if err != nil {
+		return OrchestratorRecord{}, fmt.Errorf("user_id: %w", err)
+	}
 	row := r.pool.QueryRow(ctx, `
-SELECT id, orchestrator_task_ref, task_id, plan_id, subtask_id, trace_id, data_type, timestamp, payload, ttl_seconds, created_at
+SELECT id, user_id, orchestrator_task_ref, task_id, plan_id, subtask_id, trace_id, data_type, timestamp, payload, ttl_seconds, created_at
 FROM orchestrator_schema.orchestrator_records
-WHERE task_id = $1 AND data_type = $2
+WHERE user_id = $1 AND task_id = $2 AND data_type = $3
 ORDER BY timestamp DESC
-LIMIT 1`, taskID, dataType)
+LIMIT 1`, userUUID, taskID, dataType)
 	rec, err := scanOrchestratorRecord(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return OrchestratorRecord{}, ErrOrchestratorRecordNotFound
@@ -338,6 +384,7 @@ func scanOrchestratorRecord(scanner interface {
 	var rec OrchestratorRecord
 	err := scanner.Scan(
 		&rec.ID,
+		&rec.UserID,
 		&rec.OrchestratorTaskRef,
 		&rec.TaskID,
 		&rec.PlanID,
@@ -357,6 +404,23 @@ func textValue(v string) pgtype.Text {
 		return pgtype.Text{}
 	}
 	return pgtype.Text{String: v, Valid: true}
+}
+
+func parseUUID(v string) (pgtype.UUID, error) {
+	parsed, err := uuid.Parse(v)
+	if err != nil {
+		return pgtype.UUID{}, err
+	}
+	return pgtype.UUID{Bytes: parsed, Valid: true}, nil
+}
+
+func isBlank(v string) bool {
+	for _, c := range v {
+		if c != ' ' && c != '\t' && c != '\n' && c != '\r' {
+			return false
+		}
+	}
+	return true
 }
 
 func (r OrchestratorRecord) PayloadJSON() any {

--- a/memory/scripts/init-db.sql
+++ b/memory/scripts/init-db.sql
@@ -178,6 +178,7 @@ CREATE TABLE IF NOT EXISTS orchestrator_schema.orchestrator_records (
     id UUID PRIMARY KEY,
     orchestrator_task_ref TEXT NOT NULL,
     task_id TEXT NOT NULL,
+    user_id UUID NOT NULL REFERENCES identity_schema.users(id),
     plan_id TEXT,
     subtask_id TEXT,
     trace_id VARCHAR(64),
@@ -188,21 +189,23 @@ CREATE TABLE IF NOT EXISTS orchestrator_schema.orchestrator_records (
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX IF NOT EXISTS idx_orch_records_task_id_type
-    ON orchestrator_schema.orchestrator_records (task_id, data_type, timestamp DESC);
-CREATE INDEX IF NOT EXISTS idx_orch_records_orch_ref_type
-    ON orchestrator_schema.orchestrator_records (orchestrator_task_ref, data_type, timestamp DESC);
-CREATE INDEX IF NOT EXISTS idx_orch_records_type_timestamp
-    ON orchestrator_schema.orchestrator_records (data_type, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_orch_records_user_task
+    ON orchestrator_schema.orchestrator_records (user_id, task_id);
+CREATE INDEX IF NOT EXISTS idx_orch_records_user_task_type
+    ON orchestrator_schema.orchestrator_records (user_id, task_id, data_type, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_orch_records_user_orch_ref_type
+    ON orchestrator_schema.orchestrator_records (user_id, orchestrator_task_ref, data_type, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_orch_records_user_type_timestamp
+    ON orchestrator_schema.orchestrator_records (user_id, data_type, timestamp DESC);
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_orch_records_task_state_upsert
-    ON orchestrator_schema.orchestrator_records (task_id, data_type)
+    ON orchestrator_schema.orchestrator_records (user_id, task_id, data_type)
     WHERE data_type = 'task_state';
 CREATE UNIQUE INDEX IF NOT EXISTS idx_orch_records_plan_state_upsert
-    ON orchestrator_schema.orchestrator_records (task_id, plan_id, data_type)
+    ON orchestrator_schema.orchestrator_records (user_id, task_id, plan_id, data_type)
     WHERE data_type = 'plan_state';
 CREATE UNIQUE INDEX IF NOT EXISTS idx_orch_records_subtask_state_upsert
-    ON orchestrator_schema.orchestrator_records (task_id, subtask_id, data_type)
+    ON orchestrator_schema.orchestrator_records (user_id, task_id, subtask_id, data_type)
     WHERE data_type = 'subtask_state';
 
 CREATE OR REPLACE FUNCTION orchestrator_schema.reject_append_only_mutation()

--- a/memory/tests/orchestrator_contract_test.go
+++ b/memory/tests/orchestrator_contract_test.go
@@ -8,8 +8,14 @@ import (
 	"time"
 )
 
+// testUserID is the dev_default user seeded by init-db.sql. MT-4 (#185)
+// requires every orchestrator record to be tagged with a user_id that
+// references identity_schema.users(id); the seeded row is the simplest fit
+// for black-box contract tests.
+const testUserID = "00000000-0000-0000-0000-000000000001"
+
 func TestOrchestratorRecordsRequireInternalKey(t *testing.T) {
-	status, env := apiJSONRequest(t, http.MethodGet, blackboxBaseURL()+"/api/v1/orchestrator/records?data_type=task_state&task_id=test-task", nil, nil)
+	status, env := apiJSONRequest(t, http.MethodGet, blackboxBaseURL()+"/api/v1/orchestrator/records?data_type=task_state&task_id=test-task&user_id="+testUserID, nil, nil)
 	if status != http.StatusUnauthorized {
 		t.Fatalf("status = %d, want %d", status, http.StatusUnauthorized)
 	}
@@ -18,6 +24,7 @@ func TestOrchestratorRecordsRequireInternalKey(t *testing.T) {
 
 func TestOrchestratorWriteRejectsInvalidDataType(t *testing.T) {
 	status, env := apiJSONRequest(t, http.MethodPost, blackboxBaseURL()+"/api/v1/orchestrator/records", map[string]any{
+		"user_id":               testUserID,
 		"orchestrator_task_ref": "orch-invalid",
 		"task_id":               "task-invalid",
 		"data_type":             "not_real",
@@ -51,6 +58,7 @@ func TestOrchestratorTaskStateUpserts(t *testing.T) {
 		{timestamp: secondTS, state: "PLAN_ACTIVE", retry: 1},
 	} {
 		status, env := apiJSONRequest(t, http.MethodPost, base+"/api/v1/orchestrator/records", map[string]any{
+			"user_id":               testUserID,
 			"orchestrator_task_ref": orchRef,
 			"task_id":               taskID,
 			"trace_id":              traceID,
@@ -68,7 +76,7 @@ func TestOrchestratorTaskStateUpserts(t *testing.T) {
 		assertSuccessEnvelope(t, env)
 	}
 
-	status, env := apiJSONRequest(t, http.MethodGet, base+"/api/v1/orchestrator/records?data_type=task_state&task_id="+taskID, nil, headers)
+	status, env := apiJSONRequest(t, http.MethodGet, base+"/api/v1/orchestrator/records?data_type=task_state&user_id="+testUserID+"&task_id="+taskID, nil, headers)
 	if status != http.StatusOK {
 		t.Fatalf("query status = %d, want %d", status, http.StatusOK)
 	}
@@ -95,7 +103,7 @@ func TestOrchestratorTaskStateUpserts(t *testing.T) {
 		t.Fatalf("payload.state = %v, want PLAN_ACTIVE", got)
 	}
 
-	status, env = apiJSONRequest(t, http.MethodGet, base+"/api/v1/orchestrator/records/latest?task_id="+taskID+"&data_type=task_state", nil, headers)
+	status, env = apiJSONRequest(t, http.MethodGet, base+"/api/v1/orchestrator/records/latest?user_id="+testUserID+"&task_id="+taskID+"&data_type=task_state", nil, headers)
 	if status != http.StatusOK {
 		t.Fatalf("latest status = %d, want %d", status, http.StatusOK)
 	}
@@ -126,6 +134,7 @@ func TestOrchestratorAuditLogAppends(t *testing.T) {
 
 	for i, outcome := range []string{"success", "failed"} {
 		status, env := apiJSONRequest(t, http.MethodPost, base+"/api/v1/orchestrator/records", map[string]any{
+			"user_id":               testUserID,
 			"orchestrator_task_ref": orchRef,
 			"task_id":               taskID,
 			"data_type":             "audit_log",
@@ -145,7 +154,7 @@ func TestOrchestratorAuditLogAppends(t *testing.T) {
 		assertSuccessEnvelope(t, env)
 	}
 
-	status, env := apiJSONRequest(t, http.MethodGet, base+"/api/v1/orchestrator/records?data_type=audit_log&task_id="+taskID, nil, headers)
+	status, env := apiJSONRequest(t, http.MethodGet, base+"/api/v1/orchestrator/records?data_type=audit_log&user_id="+testUserID+"&task_id="+taskID, nil, headers)
 	if status != http.StatusOK {
 		t.Fatalf("query status = %d, want %d", status, http.StatusOK)
 	}
@@ -180,6 +189,7 @@ func TestOrchestratorQueryNotTerminalFiltersTerminalStates(t *testing.T) {
 		{taskID: terminalTaskID, orch: terminalRef, state: "COMPLETED"},
 	} {
 		status, env := apiJSONRequest(t, http.MethodPost, base+"/api/v1/orchestrator/records", map[string]any{
+			"user_id":               testUserID,
 			"orchestrator_task_ref": tc.orch,
 			"task_id":               tc.taskID,
 			"data_type":             "task_state",
@@ -195,7 +205,7 @@ func TestOrchestratorQueryNotTerminalFiltersTerminalStates(t *testing.T) {
 		assertSuccessEnvelope(t, env)
 	}
 
-	status, env := apiJSONRequest(t, http.MethodGet, base+"/api/v1/orchestrator/records?data_type=task_state&state_filter=not_terminal", nil, headers)
+	status, env := apiJSONRequest(t, http.MethodGet, base+"/api/v1/orchestrator/records?data_type=task_state&user_id="+testUserID+"&state_filter=not_terminal", nil, headers)
 	if status != http.StatusOK {
 		t.Fatalf("query status = %d, want %d", status, http.StatusOK)
 	}

--- a/memory/tests/orchestrator_user_isolation_test.go
+++ b/memory/tests/orchestrator_user_isolation_test.go
@@ -1,0 +1,154 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// secondTestUserID is a second seeded user used to assert MT-4 (#185) tenant
+// isolation: a record written as user A must not surface in queries scoped to
+// user B, even when both records share the same task_id.
+const secondTestUserID = "00000000-0000-0000-0000-000000000002"
+
+func ensureSecondTestUser(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := dbPool.Exec(ctx, `
+INSERT INTO identity_schema.users (id, email, role)
+VALUES ($1, 'mt4-isolation@example.com', 'user')
+ON CONFLICT (id) DO NOTHING`,
+		secondTestUserID)
+	if err != nil {
+		t.Fatalf("seed second test user: %v", err)
+	}
+}
+
+// TestOrchestratorRecordsAreTenantIsolated is the MT-4 (#185) AC check:
+// writing the same task_id as two different users must produce two distinct
+// rows, and each user must only see their own.
+func TestOrchestratorRecordsAreTenantIsolated(t *testing.T) {
+	ensureSecondTestUser(t)
+
+	base := blackboxBaseURL()
+	headers := map[string]string{"X-Internal-API-Key": vaultKey}
+	taskID := fmt.Sprintf("task-mt4-iso-%d", time.Now().UnixNano())
+	orchRefA := "orch-A-" + uuid.NewString()
+	orchRefB := "orch-B-" + uuid.NewString()
+
+	writeFor := func(t *testing.T, userID, orchRef, state string) {
+		t.Helper()
+		status, env := apiJSONRequest(t, http.MethodPost, base+"/api/v1/orchestrator/records", map[string]any{
+			"user_id":               userID,
+			"orchestrator_task_ref": orchRef,
+			"task_id":               taskID,
+			"data_type":             "task_state",
+			"timestamp":             time.Now().UTC().Format(time.RFC3339Nano),
+			"payload": map[string]any{
+				"task_id": taskID,
+				"state":   state,
+				"owner":   userID,
+			},
+		}, headers)
+		if status != http.StatusCreated {
+			t.Fatalf("write status = %d, want %d (env=%+v)", status, http.StatusCreated, env)
+		}
+	}
+
+	writeFor(t, testUserID, orchRefA, "RUNNING_A")
+	writeFor(t, secondTestUserID, orchRefB, "RUNNING_B")
+
+	queryFor := func(t *testing.T, userID string) []map[string]any {
+		t.Helper()
+		status, env := apiJSONRequest(t, http.MethodGet,
+			base+"/api/v1/orchestrator/records?data_type=task_state&user_id="+userID+"&task_id="+taskID,
+			nil, headers)
+		if status != http.StatusOK {
+			t.Fatalf("query status = %d, want %d", status, http.StatusOK)
+		}
+		var payload struct {
+			Records []map[string]any `json:"records"`
+		}
+		if err := json.Unmarshal(env.Data, &payload); err != nil {
+			t.Fatalf("unmarshal records: %v", err)
+		}
+		return payload.Records
+	}
+
+	recsA := queryFor(t, testUserID)
+	if len(recsA) != 1 {
+		t.Fatalf("user A records = %d, want 1", len(recsA))
+	}
+	if got := recsA[0]["payload"].(map[string]any)["state"]; got != "RUNNING_A" {
+		t.Fatalf("user A payload.state = %v, want RUNNING_A", got)
+	}
+
+	recsB := queryFor(t, secondTestUserID)
+	if len(recsB) != 1 {
+		t.Fatalf("user B records = %d, want 1", len(recsB))
+	}
+	if got := recsB[0]["payload"].(map[string]any)["state"]; got != "RUNNING_B" {
+		t.Fatalf("user B payload.state = %v, want RUNNING_B", got)
+	}
+
+	// Cross-user query: user C (the second user) asking for user A's data type
+	// must NOT see user A's row even though task_id matches.
+	status, env := apiJSONRequest(t, http.MethodGet,
+		base+"/api/v1/orchestrator/records/latest?user_id="+secondTestUserID+"&task_id="+taskID+"&data_type=task_state",
+		nil, headers)
+	if status != http.StatusOK {
+		t.Fatalf("latest(B) status = %d, want %d", status, http.StatusOK)
+	}
+	var latest struct {
+		Record struct {
+			Payload map[string]any `json:"payload"`
+		} `json:"record"`
+	}
+	if err := json.Unmarshal(env.Data, &latest); err != nil {
+		t.Fatalf("unmarshal latest: %v", err)
+	}
+	if got := latest.Record.Payload["state"]; got != "RUNNING_B" {
+		t.Fatalf("latest(B).state = %v, want RUNNING_B (must not leak user A's row)", got)
+	}
+}
+
+// TestOrchestratorWriteRejectsMissingUserID guards the validation path: an
+// orchestrator record write without a user_id must be rejected at the HTTP
+// boundary so that the storage layer never sees a NULL-tenant insert.
+func TestOrchestratorWriteRejectsMissingUserID(t *testing.T) {
+	base := blackboxBaseURL()
+	headers := map[string]string{"X-Internal-API-Key": vaultKey}
+	taskID := fmt.Sprintf("task-mt4-missing-uid-%d", time.Now().UnixNano())
+
+	status, env := apiJSONRequest(t, http.MethodPost, base+"/api/v1/orchestrator/records", map[string]any{
+		"orchestrator_task_ref": "orch-missing-uid",
+		"task_id":               taskID,
+		"data_type":             "task_state",
+		"timestamp":             time.Now().UTC().Format(time.RFC3339),
+		"payload":               map[string]any{"state": "RUNNING"},
+	}, headers)
+	if status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", status, http.StatusBadRequest)
+	}
+	assertErrorCode(t, env, "invalid_argument")
+}
+
+// TestOrchestratorQueryRejectsMissingUserID guards the read path equivalent
+// of the above — reads without user_id are programming errors and must 400.
+func TestOrchestratorQueryRejectsMissingUserID(t *testing.T) {
+	base := blackboxBaseURL()
+	headers := map[string]string{"X-Internal-API-Key": vaultKey}
+
+	status, env := apiJSONRequest(t, http.MethodGet,
+		base+"/api/v1/orchestrator/records?data_type=task_state&task_id=anything",
+		nil, headers)
+	if status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", status, http.StatusBadRequest)
+	}
+	assertErrorCode(t, env, "invalid_argument")
+}

--- a/orchestrator/cmd/orchestrator/main_test.go
+++ b/orchestrator/cmd/orchestrator/main_test.go
@@ -170,7 +170,7 @@ func TestBuildRuntime_PlannerResultTransitionsTaskToPlanActive(t *testing.T) {
 		t.Fatalf("Deliver(task result) error = %v", err)
 	}
 
-	ts, err := rt.mockMemory.GetTaskState(task.TaskID)
+	ts, err := rt.mockMemory.GetTaskState(task.UserID, task.TaskID)
 	if err != nil {
 		t.Fatalf("GetTaskState() error = %v", err)
 	}

--- a/orchestrator/internal/dispatcher/dispatcher.go
+++ b/orchestrator/internal/dispatcher/dispatcher.go
@@ -226,7 +226,7 @@ func (d *Dispatcher) HandleInboundTask(ctx context.Context, task types.UserTask)
 
 	{
 		dedupCtx, dedupSpan := observability.StartSpan(ctx, "dedup_check")
-		existing := d.dedupCheck(task.TaskID, idempotencyWindow)
+		existing := d.dedupCheck(task.UserID, task.TaskID, idempotencyWindow)
 		dedupSpan.End()
 		_ = dedupCtx
 		// A task_id is only a "duplicate" while a prior attempt is still in
@@ -578,7 +578,7 @@ func (d *Dispatcher) enterAwaitingApproval(ctx context.Context, ts *types.TaskSt
 	if err := d.persistTaskState(ts, now); err != nil {
 		log.Warn("could not persist task transition to AWAITING_APPROVAL in memory; continuing in-process", "error", err)
 	}
-	if err := d.persistPlanState(plan, ts.TaskID, ts.OrchestratorTaskRef, now); err != nil {
+	if err := d.persistPlanState(plan, ts, now); err != nil {
 		log.Warn("could not persist execution plan to memory; continuing in-process", "plan_id", plan.PlanID, "error", err)
 	}
 
@@ -668,7 +668,7 @@ func (d *Dispatcher) startPlanExecution(ctx context.Context, ts *types.TaskState
 	if err := d.persistTaskState(ts, now); err != nil {
 		log.Warn("could not persist task transition to PLAN_ACTIVE in memory; continuing in-process", "error", err)
 	}
-	if err := d.persistPlanState(plan, ts.TaskID, ts.OrchestratorTaskRef, now); err != nil {
+	if err := d.persistPlanState(plan, ts, now); err != nil {
 		log.Warn("could not persist execution plan to memory on PLAN_ACTIVE; continuing in-process", "plan_id", plan.PlanID, "error", err)
 	}
 
@@ -1397,9 +1397,11 @@ func classifyPlanError(err error) string {
 
 // dedupCheck queries Memory for an existing task_state within the idempotency window.
 // Returns the existing TaskState if a duplicate is found, or nil if the task is new.
-func (d *Dispatcher) dedupCheck(taskID string, windowSeconds int) *types.TaskState {
+// MT-4 (#185): scoped to userID so two tenants with colliding task_ids do not collide.
+func (d *Dispatcher) dedupCheck(userID, taskID string, windowSeconds int) *types.TaskState {
 	windowStart := time.Now().UTC().Add(-time.Duration(windowSeconds) * time.Second)
 	records, err := d.memory.Read(types.MemoryQuery{
+		UserID:        userID,
 		TaskID:        taskID,
 		DataType:      types.DataTypeTaskState,
 		FromTimestamp: &windowStart,
@@ -1422,6 +1424,7 @@ func (d *Dispatcher) persistTaskState(ts *types.TaskState, timestamp time.Time) 
 	}
 
 	return d.memory.Write(types.OrchestratorMemoryWritePayload{
+		UserID:              ts.UserID,
 		OrchestratorTaskRef: ts.OrchestratorTaskRef,
 		TaskID:              ts.TaskID,
 		DataType:            types.DataTypeTaskState,
@@ -1430,15 +1433,16 @@ func (d *Dispatcher) persistTaskState(ts *types.TaskState, timestamp time.Time) 
 	})
 }
 
-func (d *Dispatcher) persistPlanState(plan types.ExecutionPlan, taskID, orchRef string, timestamp time.Time) error {
+func (d *Dispatcher) persistPlanState(plan types.ExecutionPlan, ts *types.TaskState, timestamp time.Time) error {
 	planPayload, err := json.Marshal(plan)
 	if err != nil {
 		return fmt.Errorf("marshal plan: %w", err)
 	}
 
 	return d.memory.Write(types.OrchestratorMemoryWritePayload{
-		OrchestratorTaskRef: orchRef,
-		TaskID:              taskID,
+		UserID:              ts.UserID,
+		OrchestratorTaskRef: ts.OrchestratorTaskRef,
+		TaskID:              ts.TaskID,
 		PlanID:              plan.PlanID,
 		DataType:            types.DataTypePlanState,
 		Timestamp:           timestamp,

--- a/orchestrator/internal/dispatcher/dispatcher_test.go
+++ b/orchestrator/internal/dispatcher/dispatcher_test.go
@@ -857,6 +857,7 @@ func TestHandleInboundTask_ReEntryAfterTerminalState(t *testing.T) {
 		t.Fatalf("marshal terminal state: %v", err)
 	}
 	if err := mem.Write(types.OrchestratorMemoryWritePayload{
+		UserID:              terminalState.UserID,
 		OrchestratorTaskRef: terminalState.OrchestratorTaskRef,
 		TaskID:              task.TaskID,
 		DataType:            types.DataTypeTaskState,

--- a/orchestrator/internal/executor/executor.go
+++ b/orchestrator/internal/executor/executor.go
@@ -292,6 +292,7 @@ func (e *PlanExecutor) Execute(ctx context.Context, plan types.ExecutionPlan, ts
 			SubtaskID:            st.SubtaskID,
 			PlanID:               plan.PlanID,
 			TaskID:               ts.TaskID,
+			UserID:               ts.UserID,
 			State:                types.SubtaskStatePending,
 			RequiredSkillDomains: st.RequiredSkillDomains,
 			DependsOn:            st.DependsOn,
@@ -746,6 +747,7 @@ func (e *PlanExecutor) persistSubtaskState(sub *types.SubtaskState, orchRef stri
 	}
 
 	if err := e.memory.Write(types.OrchestratorMemoryWritePayload{
+		UserID:              sub.UserID,
 		OrchestratorTaskRef: orchRef,
 		TaskID:              sub.TaskID,
 		PlanID:              sub.PlanID,

--- a/orchestrator/internal/interfaces/memory.go
+++ b/orchestrator/internal/interfaces/memory.go
@@ -22,9 +22,10 @@ type MemoryClient interface {
 	// Supports filtering by orchestrator_task_ref OR task_id, data_type, and time range (§11.4).
 	Read(query types.MemoryQuery) ([]types.MemoryRecord, error)
 
-	// ReadLatest retrieves the single most recent record for a given task_id and data_type.
+	// ReadLatest retrieves the single most recent record for a given user_id, task_id and data_type.
 	// Used by Recovery Manager to restore the last valid task state before re-dispatch (§FR-SH-02).
-	ReadLatest(taskID string, dataType string) (*types.MemoryRecord, error)
+	// MT-4 (#185): userID is required and is the leading filter.
+	ReadLatest(userID, taskID, dataType string) (*types.MemoryRecord, error)
 
 	// Ping checks Memory Component reachability.
 	// Used by the health monitoring loop every 10 seconds (§12.1).

--- a/orchestrator/internal/memory/interface.go
+++ b/orchestrator/internal/memory/interface.go
@@ -99,6 +99,9 @@ func (i *Interface) Write(payload types.OrchestratorMemoryWritePayload) error {
 
 // Read retrieves all matching records ordered by timestamp ascending (§11.4).
 func (i *Interface) Read(query types.MemoryQuery) ([]types.MemoryRecord, error) {
+	if query.UserID == "" {
+		return nil, fmt.Errorf("user_id is required")
+	}
 	if !isValidDataType(query.DataType) {
 		return nil, fmt.Errorf("invalid data_type: %q", query.DataType)
 	}
@@ -112,9 +115,13 @@ func (i *Interface) Read(query types.MemoryQuery) ([]types.MemoryRecord, error) 
 	return i.client.Read(query)
 }
 
-// ReadLatest retrieves the most recent record for a given task_id and data_type.
+// ReadLatest retrieves the most recent record for a given user_id, task_id and data_type.
 // Used by Recovery Manager to restore the last valid task state (§FR-SH-02).
-func (i *Interface) ReadLatest(taskID string, dataType string) (*types.MemoryRecord, error) {
+// MT-4 (#185): userID is required; reads must be tenant-scoped.
+func (i *Interface) ReadLatest(userID, taskID, dataType string) (*types.MemoryRecord, error) {
+	if userID == "" {
+		return nil, fmt.Errorf("user_id is required")
+	}
 	if taskID == "" {
 		return nil, fmt.Errorf("task_id is required")
 	}
@@ -122,7 +129,7 @@ func (i *Interface) ReadLatest(taskID string, dataType string) (*types.MemoryRec
 		return nil, fmt.Errorf("invalid data_type: %q", dataType)
 	}
 
-	return i.client.ReadLatest(taskID, dataType)
+	return i.client.ReadLatest(userID, taskID, dataType)
 }
 
 // Ping checks Memory Component reachability (§12.1).
@@ -141,6 +148,9 @@ func (i *Interface) MigrateSchema() error {
 }
 
 func validateWritePayload(payload types.OrchestratorMemoryWritePayload) error {
+	if payload.UserID == "" {
+		return fmt.Errorf("user_id is required")
+	}
 	if payload.OrchestratorTaskRef == "" {
 		return fmt.Errorf("orchestrator_task_ref is required")
 	}

--- a/orchestrator/internal/memory/interface_test.go
+++ b/orchestrator/internal/memory/interface_test.go
@@ -13,6 +13,10 @@ import (
 	"github.com/mlim3/cerberOS/orchestrator/internal/types"
 )
 
+// testUserID is a fixed UUID used by all orchestrator-memory tests so writes/reads
+// satisfy the MT-4 (#185) user_id contract.
+const testUserID = "00000000-0000-0000-0000-000000000001"
+
 // TestWriteValidDataTypeSucceeds verifies that Write succeeds
 // when the payload contains a valid DataType.
 // It also checks that the underlying memory layer is called once
@@ -112,6 +116,7 @@ func TestReadReturnsRecordsOrderedByTimestampAscending(t *testing.T) {
 
 	mem.Records = []types.MemoryRecord{
 		{
+			UserID:              testUserID,
 			OrchestratorTaskRef: "orch-1",
 			TaskID:              "task-1",
 			DataType:            types.DataTypeTaskState,
@@ -119,6 +124,7 @@ func TestReadReturnsRecordsOrderedByTimestampAscending(t *testing.T) {
 			Payload:             mustJSON(t, map[string]any{"state": "RUNNING"}),
 		},
 		{
+			UserID:              testUserID,
 			OrchestratorTaskRef: "orch-1",
 			TaskID:              "task-1",
 			DataType:            types.DataTypeTaskState,
@@ -128,6 +134,7 @@ func TestReadReturnsRecordsOrderedByTimestampAscending(t *testing.T) {
 	}
 
 	records, err := iface.Read(types.MemoryQuery{
+		UserID:   testUserID,
 		TaskID:   "task-1",
 		DataType: types.DataTypeTaskState,
 	})
@@ -152,6 +159,7 @@ func TestReadInvalidDataTypeReturnsError(t *testing.T) {
 	iface := memoryiface.New(mem, &config.OrchestratorConfig{})
 
 	_, err := iface.Read(types.MemoryQuery{
+		UserID:   testUserID,
 		TaskID:   "task-1",
 		DataType: "bad_type",
 	})
@@ -177,6 +185,7 @@ func TestReadLatestReturnsNewestRecord(t *testing.T) {
 
 	mem.Records = []types.MemoryRecord{
 		{
+			UserID:              testUserID,
 			OrchestratorTaskRef: "orch-1",
 			TaskID:              "task-1",
 			DataType:            types.DataTypeTaskState,
@@ -184,6 +193,7 @@ func TestReadLatestReturnsNewestRecord(t *testing.T) {
 			Payload:             mustJSON(t, map[string]any{"state": "DISPATCHED"}),
 		},
 		{
+			UserID:              testUserID,
 			OrchestratorTaskRef: "orch-1",
 			TaskID:              "task-1",
 			DataType:            types.DataTypeTaskState,
@@ -192,7 +202,7 @@ func TestReadLatestReturnsNewestRecord(t *testing.T) {
 		},
 	}
 
-	record, err := iface.ReadLatest("task-1", types.DataTypeTaskState)
+	record, err := iface.ReadLatest(testUserID, "task-1", types.DataTypeTaskState)
 	if err != nil {
 		t.Fatalf("ReadLatest() error = %v", err)
 	}
@@ -207,12 +217,27 @@ func TestReadLatestEmptyTaskIDReturnsError(t *testing.T) {
 	mem := mocks.NewMemoryMock()
 	iface := memoryiface.New(mem, &config.OrchestratorConfig{})
 
-	_, err := iface.ReadLatest("", types.DataTypeTaskState)
+	_, err := iface.ReadLatest(testUserID, "", types.DataTypeTaskState)
 	if err == nil {
 		t.Fatal("ReadLatest() error = nil, want task_id required error")
 	}
 	if !strings.Contains(err.Error(), "task_id is required") {
 		t.Fatalf("ReadLatest() error = %v, want task_id is required", err)
+	}
+}
+
+// TestReadLatestEmptyUserIDReturnsError verifies that ReadLatest rejects
+// empty user IDs — MT-4 (#185) requires every read to be tenant-scoped.
+func TestReadLatestEmptyUserIDReturnsError(t *testing.T) {
+	mem := mocks.NewMemoryMock()
+	iface := memoryiface.New(mem, &config.OrchestratorConfig{})
+
+	_, err := iface.ReadLatest("", "task-1", types.DataTypeTaskState)
+	if err == nil {
+		t.Fatal("ReadLatest() error = nil, want user_id required error")
+	}
+	if !strings.Contains(err.Error(), "user_id is required") {
+		t.Fatalf("ReadLatest() error = %v, want user_id is required", err)
 	}
 }
 
@@ -276,6 +301,7 @@ func TestMemoryInterfaceDemoFlow(t *testing.T) {
 	// The payload is a structured task_state record, not a raw transcript.
 	dispatchedAt := time.Now().UTC().Add(-2 * time.Minute)
 	dispatchedPayload := types.OrchestratorMemoryWritePayload{
+		UserID:              testUserID,
 		OrchestratorTaskRef: "orch-demo-1",
 		TaskID:              "task-demo-1",
 		DataType:            types.DataTypeTaskState,
@@ -296,6 +322,7 @@ func TestMemoryInterfaceDemoFlow(t *testing.T) {
 	// Using the same task_id but a later timestamp lets us verify ReadLatest.
 	runningAt := dispatchedAt.Add(1 * time.Minute)
 	runningPayload := types.OrchestratorMemoryWritePayload{
+		UserID:              testUserID,
 		OrchestratorTaskRef: "orch-demo-1",
 		TaskID:              "task-demo-1",
 		DataType:            types.DataTypeTaskState,
@@ -317,6 +344,7 @@ func TestMemoryInterfaceDemoFlow(t *testing.T) {
 	// other orchestrator modules.
 	t.Log("step 3: reading all task_state records for task-demo-1")
 	records, err := iface.Read(types.MemoryQuery{
+		UserID:   testUserID,
 		TaskID:   "task-demo-1",
 		DataType: types.DataTypeTaskState,
 	})
@@ -340,7 +368,7 @@ func TestMemoryInterfaceDemoFlow(t *testing.T) {
 	// This is the recovery-oriented read path where orchestrator wants the most
 	// recent structured state for a task.
 	t.Log("step 4: reading latest task_state snapshot for task-demo-1")
-	latest, err := iface.ReadLatest("task-demo-1", types.DataTypeTaskState)
+	latest, err := iface.ReadLatest(testUserID, "task-demo-1", types.DataTypeTaskState)
 	if err != nil {
 		t.Fatalf("ReadLatest() error = %v", err)
 	}
@@ -382,6 +410,7 @@ func newWritePayload(t *testing.T, dataType string) types.OrchestratorMemoryWrit
 	t.Helper()
 
 	return types.OrchestratorMemoryWritePayload{
+		UserID:              testUserID,
 		OrchestratorTaskRef: "orch-1",
 		TaskID:              "task-1",
 		DataType:            dataType,

--- a/orchestrator/internal/mocks/memory_mock.go
+++ b/orchestrator/internal/mocks/memory_mock.go
@@ -59,7 +59,13 @@ func (m *MemoryMock) Write(payload types.OrchestratorMemoryWritePayload) error {
 		return fmt.Errorf("invalid data_type: %q — must be one of: task_state, plan_state, subtask_state, audit_log, recovery_event, policy_event", payload.DataType)
 	}
 
+	// MT-4 (#185): mock now stores user_id so tests can exercise tenant isolation.
+	if payload.UserID == "" {
+		return errors.New("user_id is required")
+	}
+
 	m.Records = append(m.Records, types.MemoryRecord{
+		UserID:              payload.UserID,
 		OrchestratorTaskRef: payload.OrchestratorTaskRef,
 		TaskID:              payload.TaskID,
 		DataType:            payload.DataType,
@@ -96,7 +102,7 @@ func (m *MemoryMock) Read(query types.MemoryQuery) ([]types.MemoryRecord, error)
 	return results, nil
 }
 
-func (m *MemoryMock) ReadLatest(taskID string, dataType string) (*types.MemoryRecord, error) {
+func (m *MemoryMock) ReadLatest(userID, taskID, dataType string) (*types.MemoryRecord, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -106,10 +112,14 @@ func (m *MemoryMock) ReadLatest(taskID string, dataType string) (*types.MemoryRe
 		return nil, errors.New("memory component unavailable")
 	}
 
+	if userID == "" {
+		return nil, errors.New("user_id is required")
+	}
+
 	var latest *types.MemoryRecord
 	for i := range m.Records {
 		r := &m.Records[i]
-		if r.TaskID != taskID || r.DataType != dataType {
+		if r.UserID != userID || r.TaskID != taskID || r.DataType != dataType {
 			continue
 		}
 		if latest == nil || r.Timestamp.After(latest.Timestamp) {
@@ -118,7 +128,7 @@ func (m *MemoryMock) ReadLatest(taskID string, dataType string) (*types.MemoryRe
 	}
 
 	if latest == nil {
-		return nil, fmt.Errorf("no records found for task_id=%s data_type=%s", taskID, dataType)
+		return nil, fmt.Errorf("no records found for user_id=%s task_id=%s data_type=%s", userID, taskID, dataType)
 	}
 
 	return latest, nil
@@ -136,9 +146,10 @@ func (m *MemoryMock) Ping() error {
 	return nil
 }
 
-// GetTaskState is a test helper that deserializes the latest task_state record for a given task.
-func (m *MemoryMock) GetTaskState(taskID string) (*types.TaskState, error) {
-	record, err := m.ReadLatest(taskID, types.DataTypeTaskState)
+// GetTaskState is a test helper that deserializes the latest task_state record
+// for a given user and task. MT-4 (#185): scoped to userID.
+func (m *MemoryMock) GetTaskState(userID, taskID string) (*types.TaskState, error) {
+	record, err := m.ReadLatest(userID, taskID, types.DataTypeTaskState)
 	if err != nil {
 		return nil, err
 	}
@@ -165,6 +176,9 @@ func (m *MemoryMock) Reset() {
 
 // matchesQuery checks if a MemoryRecord satisfies the given MemoryQuery filters.
 func matchesQuery(r types.MemoryRecord, q types.MemoryQuery) bool {
+	if q.UserID != "" && r.UserID != q.UserID {
+		return false
+	}
 	if q.DataType != "" && r.DataType != q.DataType {
 		return false
 	}
@@ -198,7 +212,7 @@ func matchesQuery(r types.MemoryRecord, q types.MemoryQuery) bool {
 var _ interface {
 	Write(types.OrchestratorMemoryWritePayload) error
 	Read(types.MemoryQuery) ([]types.MemoryRecord, error)
-	ReadLatest(string, string) (*types.MemoryRecord, error)
+	ReadLatest(string, string, string) (*types.MemoryRecord, error)
 	Ping() error
 } = &MemoryMock{}
 

--- a/orchestrator/internal/monitor/monitor.go
+++ b/orchestrator/internal/monitor/monitor.go
@@ -49,13 +49,12 @@ func (m *Monitor) RehydrateFromMemory() error {
 	log := observability.LogFromContext(observability.WithModule(context.Background(), "task_monitor"))
 	log.Info("task monitor rehydration started")
 
-	records, err := m.memory.Read(types.MemoryQuery{
-		DataType: types.DataTypeTaskState,
-		Filter:   map[string]string{"state": "not_terminal"},
-	})
-	if err != nil {
-		return fmt.Errorf("rehydrate task states: %w", err)
-	}
+	// TODO(#189 / MT-14): rehydrate is not yet tenant-aware. Memory reads are now
+	// scoped to user_id (MT-4 #185), so a global, unfiltered rehydrate is no
+	// longer supported. Until MT-14 wires per-tenant rehydrate, we skip and rely
+	// on tasks naturally resuming via their next inbound signal. This is an
+	// accepted regression for MT-4 (see #185 "Out of scope").
+	var records []types.MemoryRecord
 
 	latestByTask := make(map[string]*types.TaskState)
 	for _, record := range records {
@@ -159,6 +158,7 @@ func (m *Monitor) StateTransition(_ context.Context, taskID, newState, reason st
 		return fmt.Errorf("marshal task state transition for task %s: %w", taskID, err)
 	}
 	if err := m.memory.Write(types.OrchestratorMemoryWritePayload{
+		UserID:              ts.UserID,
 		OrchestratorTaskRef: ts.OrchestratorTaskRef,
 		TaskID:              ts.TaskID,
 		DataType:            types.DataTypeTaskState,

--- a/orchestrator/internal/monitor/monitor_test.go
+++ b/orchestrator/internal/monitor/monitor_test.go
@@ -107,6 +107,7 @@ func seedTaskState(t *testing.T, mem *mocks.MemoryMock, ts *types.TaskState) {
 	}
 
 	if err := mem.Write(types.OrchestratorMemoryWritePayload{
+		UserID:              ts.UserID,
 		OrchestratorTaskRef: ts.OrchestratorTaskRef,
 		TaskID:              ts.TaskID,
 		DataType:            types.DataTypeTaskState,
@@ -118,51 +119,24 @@ func seedTaskState(t *testing.T, mem *mocks.MemoryMock, ts *types.TaskState) {
 }
 
 // ── Rehydrate ────────────────────────────────────────────────────────────────
+//
+// MT-4 (#185): RehydrateFromMemory is intentionally a no-op until MT-14
+// (#189) wires per-tenant rehydrate. The tests below now assert the temporary
+// "loads nothing" contract; once #189 lands they should be restored to their
+// previous shape (loading newest-per-task, skipping terminal states).
 
-func TestRehydrateFromMemory_LoadsLatestNonTerminalTasks(t *testing.T) {
+func TestRehydrateFromMemory_IsNoOpUntilMT14(t *testing.T) {
 	m, mem, _ := newMonitor(t)
 
-	ts1Old := makeTaskState("task-1", types.StateDispatchPending)
-	ts1New := makeTaskState("task-1", types.StateRunning)
-	ts1New.StateHistory = append(ts1New.StateHistory, types.StateEvent{
-		State:     types.StateRunning,
-		Timestamp: time.Now().UTC().Add(1 * time.Second),
-		NodeID:    "test-node",
-	})
-
-	ts2Terminal := makeTaskState("task-2", types.StateCompleted)
-	now := time.Now().UTC()
-	ts2Terminal.CompletedAt = &now
-
-	seedTaskState(t, mem, ts1Old)
-	seedTaskState(t, mem, ts1New)
-	seedTaskState(t, mem, ts2Terminal)
+	ts1 := makeTaskState("task-1", types.StateRunning)
+	seedTaskState(t, mem, ts1)
 
 	if err := m.RehydrateFromMemory(); err != nil {
 		t.Fatalf("RehydrateFromMemory() error = %v", err)
 	}
 
-	if got := m.GetActiveTaskCount(); got != 1 {
-		t.Fatalf("GetActiveTaskCount() = %d, want 1", got)
-	}
-}
-
-func TestRehydrateFromMemory_ReturnsErrorOnBadPayload(t *testing.T) {
-	m, mem, _ := newMonitor(t)
-
-	if err := mem.Write(types.OrchestratorMemoryWritePayload{
-		OrchestratorTaskRef: "orch-bad",
-		TaskID:              "task-bad",
-		DataType:            types.DataTypeTaskState,
-		Timestamp:           time.Now().UTC(),
-		Payload:             json.RawMessage(`{"state":`), // malformed json
-	}); err != nil {
-		t.Fatalf("memory.Write() error = %v", err)
-	}
-
-	err := m.RehydrateFromMemory()
-	if err == nil {
-		t.Fatal("RehydrateFromMemory() error = nil, want non-nil")
+	if got := m.GetActiveTaskCount(); got != 0 {
+		t.Fatalf("GetActiveTaskCount() = %d, want 0 (rehydrate is a no-op pending #189)", got)
 	}
 }
 
@@ -489,9 +463,11 @@ func TestMonitorDemoFlow(t *testing.T) {
 	t.Log("demo setup: created recoveryMock as the mock Recovery Manager")
 	t.Log("demo setup: created monitor.Monitor as the orchestrator-side M4 monitor")
 
-	// Step 1: simulate startup rehydration from Memory.
-	// We seed one non-terminal DISPATCHED task so the monitor can load it.
-	t.Log("step 1: seeding Memory with a non-terminal DISPATCHED task for startup rehydration")
+	// Step 1: simulate startup tracking.
+	// MT-4 (#185): RehydrateFromMemory is a no-op until MT-14 (#189) wires
+	// per-tenant rehydrate. For now we exercise TrackTask directly so the rest
+	// of the demo (agent status update → state transition → persist) still runs.
+	t.Log("step 1: seeding Memory and tracking a non-terminal DISPATCHED task")
 
 	dispatchedTask := makeTaskState("task-demo-1", types.StateDispatched)
 	dispatchedTask.TimeoutAt = ptrTime(time.Now().UTC().Add(2 * time.Minute))
@@ -500,10 +476,11 @@ func TestMonitorDemoFlow(t *testing.T) {
 	if err := m.RehydrateFromMemory(); err != nil {
 		t.Fatalf("RehydrateFromMemory() error = %v", err)
 	}
+	m.TrackTask(dispatchedTask)
 	if got := m.GetActiveTaskCount(); got != 1 {
-		t.Fatalf("GetActiveTaskCount() after rehydrate = %d, want 1", got)
+		t.Fatalf("GetActiveTaskCount() after track = %d, want 1", got)
 	}
-	t.Logf("step 1 complete: monitor rehydrated %d active task", m.GetActiveTaskCount())
+	t.Logf("step 1 complete: monitor tracking %d active task", m.GetActiveTaskCount())
 
 	// Step 2: agent reports ACTIVE.
 	// This should move the task from DISPATCHED -> RUNNING and persist the new state.

--- a/orchestrator/internal/policy/enforcer.go
+++ b/orchestrator/internal/policy/enforcer.go
@@ -194,6 +194,7 @@ func (e *Enforcer) writeAuditEvent(_ context.Context, taskID, orchestratorTaskRe
 	}
 
 	if err := e.memory.Write(types.OrchestratorMemoryWritePayload{
+		UserID:              userID,
 		OrchestratorTaskRef: orchestratorTaskRef,
 		TaskID:              taskID,
 		DataType:            types.DataTypePolicyEvent,

--- a/orchestrator/internal/recovery/manager.go
+++ b/orchestrator/internal/recovery/manager.go
@@ -181,7 +181,7 @@ func (m *Manager) attemptRecovery(ctx context.Context, ts *types.TaskState, reas
 	}
 
 	// ── Read last task state from Memory (§FR-SH-02) ──────────────────────
-	latestState, err := m.memory.ReadLatest(ts.TaskID, types.DataTypeTaskState)
+	latestState, err := m.memory.ReadLatest(ts.UserID, ts.TaskID, types.DataTypeTaskState)
 	if err != nil {
 		logger.Error("failed to read task state for recovery — terminating",
 			"task_id", ts.TaskID,
@@ -230,6 +230,7 @@ func (m *Manager) attemptRecovery(ctx context.Context, ts *types.TaskState, reas
 	eventPayload, err := json.Marshal(recoveryEvent)
 	if err == nil {
 		if writeErr := m.memory.Write(types.OrchestratorMemoryWritePayload{
+			UserID:              recoveredState.UserID,
 			OrchestratorTaskRef: recoveredState.OrchestratorTaskRef,
 			TaskID:              recoveredState.TaskID,
 			DataType:            types.DataTypeRecoveryEvent,

--- a/orchestrator/internal/recovery/manager_test.go
+++ b/orchestrator/internal/recovery/manager_test.go
@@ -161,6 +161,7 @@ func seedMemory(t *testing.T, mem *mocks.MemoryMock, ts *types.TaskState) {
 		t.Fatalf("seedMemory: marshal error = %v", err)
 	}
 	mem.Records = append(mem.Records, types.MemoryRecord{
+		UserID:              ts.UserID,
 		OrchestratorTaskRef: ts.OrchestratorTaskRef,
 		TaskID:              ts.TaskID,
 		DataType:            types.DataTypeTaskState,

--- a/orchestrator/internal/types/memory.go
+++ b/orchestrator/internal/types/memory.go
@@ -23,6 +23,7 @@ const (
 // All fields are required. Untagged payloads are rejected.
 
 type OrchestratorMemoryWritePayload struct {
+	UserID              string          `json:"user_id"` // Required — owning tenant, persisted on every orchestrator record (MT-4 #185).
 	OrchestratorTaskRef string          `json:"orchestrator_task_ref"`
 	TaskID              string          `json:"task_id"`
 	PlanID              string          `json:"plan_id,omitempty"`    // NEW v3.0 — set for plan_state and subtask_state writes
@@ -37,6 +38,7 @@ type OrchestratorMemoryWritePayload struct {
 // Read request sent to Memory Interface (§11.4).
 
 type MemoryQuery struct {
+	UserID              string            `json:"user_id"` // Required — every read is scoped to one tenant (MT-4 #185).
 	OrchestratorTaskRef string            `json:"orchestrator_task_ref,omitempty"`
 	TaskID              string            `json:"task_id,omitempty"`
 	DataType            string            `json:"data_type"`
@@ -49,6 +51,7 @@ type MemoryQuery struct {
 // A single record returned by a Memory Interface read operation.
 
 type MemoryRecord struct {
+	UserID              string          `json:"user_id"`
 	OrchestratorTaskRef string          `json:"orchestrator_task_ref"`
 	TaskID              string          `json:"task_id"`
 	DataType            string          `json:"data_type"`

--- a/orchestrator/internal/types/task.go
+++ b/orchestrator/internal/types/task.go
@@ -193,6 +193,7 @@ type SubtaskState struct {
 	SubtaskID            string          `json:"subtask_id"`
 	PlanID               string          `json:"plan_id"`
 	TaskID               string          `json:"task_id"`
+	UserID               string          `json:"user_id"`                         // MT-4 (#185) — owning tenant, propagated from parent TaskState.UserID.
 	OrchestratorTaskRef  string          `json:"orchestrator_task_ref,omitempty"` // Set at dispatch; used to route task_result back
 	State                string          `json:"state"`
 	AgentID              string          `json:"agent_id,omitempty"`


### PR DESCRIPTION
## Summary
- Adds `user_id UUID NOT NULL REFERENCES identity_schema.users(id)` to `orchestrator_schema.orchestrator_records` and rewrites every read, write, and upsert path to filter by it.
- Plumbs `UserID` through `OrchestratorMemoryWritePayload`, `MemoryQuery`, `Interface.ReadLatest`, `interfaces.MemoryClient`, `SubtaskState`, and the seven orchestrator call sites that persist task / plan / subtask / recovery / policy state.
- Drops the pre-MT-4 indexes that allowed silent cross-tenant overwrite via the unique upsert keys; replaces them with `(user_id, …)`-leading variants.
- Dev-DB blow-away: `EnsureSchema()` `TRUNCATE`s `orchestrator_records` (wrapped in a no-op-on-missing-table block) so the new `NOT NULL` column can be added without a row-by-row backfill, per the AC.

## Acceptance criteria (from #185)
- [x] Migration adds `user_id UUID NOT NULL REFERENCES identity_schema.users(id)`
- [x] Backfill: dev-DB blow-away via `TRUNCATE` in `EnsureSchema()`
- [x] Index `(user_id, task_id)` (plus supplementary user-leading indexes)
- [x] All repository read/write paths filter by `user_id`
- [x] Black-box test: write as A, read as B → empty result (`memory/tests/orchestrator_user_isolation_test.go`)

## Out of scope (per #185)
- MT-14 (#189): tenant-aware monitor rehydrate. This PR turns `RehydrateFromMemory` into a no-op with an explicit `TODO(#189)` — the unfiltered, global rehydrate is no longer compatible with the user-scoped read contract. Restoring rehydrate is MT-14's job.
- MT-5 (#186) / MT-6 (#187): not touched.

## Test plan
- [x] `go build ./...` in `memory/` and `orchestrator/`
- [x] `go vet ./...` in both modules (only pre-existing warning in `tests/contract_test_helpers_test.go`)
- [x] `go test ./...` in `orchestrator/` — all packages green
- [ ] Manual: `psql` `\d+ orchestrator_schema.orchestrator_records` shows the column + new indexes
- [ ] Manual: two-user smoke — POST `/api/tasks` as A, then `GET /api/v1/orchestrator/records?user_id=<B>&task_id=<A's task>&data_type=task_state` → `[]`
- [ ] Memory integration suite (`memory/tests/`) — requires running Postgres; not exercised locally

Closes #185. Umbrella: #178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)