### PR TITLE
feat(credential-flow): parallel simultaneous credential input with inline side-by-side cards

### DIFF
--- a/agents-component/cmd/agent-process/loop.go
+++ b/agents-component/cmd/agent-process/loop.go
@@ -433,7 +433,12 @@ func RunLoop(ctx context.Context, log *slog.Logger, spawnCtx *SpawnContext, ve *
 				)
 				// Thread actCtx so vault operations are cancelled on steering interrupt.
 				// actParentID propagates to vault tools for session log linking (EDD §13.4).
+				// WithCredentialCancelCtx embeds actCtx as a value so requestCredentialAndRetry
+				// can retrieve it after dispatchTool wraps toolCtx with a per-tool deadline;
+				// the credential poll loop monitors actCtx.Done() for steering interrupts
+				// without being affected by the per-tool timeout.
 				toolCtx := WithParentEntryID(actCtx, actParentID)
+				toolCtx = WithCredentialCancelCtx(toolCtx, actCtx)
 				start := time.Now()
 				result := dispatchTool(toolCtx, tools, c.name, c.input)
 				outcomes[idx] = toolOutcome{call: c, result: result, elapsedMS: time.Since(start).Milliseconds()}

--- a/agents-component/cmd/agent-process/main.go
+++ b/agents-component/cmd/agent-process/main.go
@@ -284,7 +284,7 @@ func runOneTask(rootCtx context.Context, rootLog *slog.Logger, spawnCtx *SpawnCo
 	// (ADR-004). Returns nil if NATS env vars are absent — non-credentialed tools
 	// continue to function normally. Task-scoped so each task gets its own
 	// permission token binding.
-	ve := NewVaultExecutor(log, spawnCtx.TaskID, spawnCtx.PermissionToken, spawnCtx.TraceID)
+	ve := NewVaultExecutor(log, taskCtx, spawnCtx.TaskID, spawnCtx.PermissionToken, spawnCtx.TraceID)
 	if ve != nil {
 		defer ve.Close()
 	}

--- a/agents-component/cmd/agent-process/main.go
+++ b/agents-component/cmd/agent-process/main.go
@@ -284,7 +284,7 @@ func runOneTask(rootCtx context.Context, rootLog *slog.Logger, spawnCtx *SpawnCo
 	// (ADR-004). Returns nil if NATS env vars are absent — non-credentialed tools
 	// continue to function normally. Task-scoped so each task gets its own
 	// permission token binding.
-	ve := NewVaultExecutor(log, taskCtx, spawnCtx.TaskID, spawnCtx.PermissionToken, spawnCtx.TraceID)
+	ve := NewVaultExecutor(log, spawnCtx.TaskID, spawnCtx.PermissionToken, spawnCtx.TraceID)
 	if ve != nil {
 		defer ve.Close()
 	}

--- a/agents-component/cmd/agent-process/vault.go
+++ b/agents-component/cmd/agent-process/vault.go
@@ -583,7 +583,7 @@ func (ve *VaultExecutor) Execute(ctx context.Context, operationType, credentialT
 // credentialRequestTimeout is how long requestCredentialAndRetry polls for the
 // user to enter a missing API key via the IO credential modal before giving up.
 const (
-	credentialRequestTimeout = 5 * time.Minute
+	credentialRequestTimeout = 8 * time.Minute
 	credentialPollInterval   = 8 * time.Second
 )
 
@@ -733,13 +733,19 @@ func (ve *VaultExecutor) requestCredentialAndRetry(
 		"timeout", credentialRequestTimeout,
 	)
 
-	// Poll vault_google_search with withCredentialRetryCtx so Execute() does not
-	// re-enter this function. The poll succeeds as soon as the user stores the key.
+	// Poll vault with withCredentialRetryCtx so Execute() does not re-enter
+	// this function. Use context.WithoutCancel so the poll survives the tool's
+	// per-call timeout (e.g. vault_github_request timeout_seconds:35) — the
+	// credential wait is user-paced, not API-call-paced. The pollCtx still
+	// carries ctx Values (needed for withCredentialRetryCtx) but is not
+	// cancelled when the tool deadline fires; it has its own 8-minute budget.
+	pollCtx, pollCancel := context.WithTimeout(context.WithoutCancel(ctx), credentialRequestTimeout)
+	defer pollCancel()
 	deadline := time.Now().Add(credentialRequestTimeout)
-	retryCtx := withCredentialRetryCtx(ctx)
+	retryCtx := withCredentialRetryCtx(pollCtx)
 	for time.Now().Before(deadline) {
 		select {
-		case <-ctx.Done():
+		case <-pollCtx.Done():
 			return nil
 		case <-time.After(credentialPollInterval):
 		}

--- a/agents-component/cmd/agent-process/vault.go
+++ b/agents-component/cmd/agent-process/vault.go
@@ -733,19 +733,31 @@ func (ve *VaultExecutor) requestCredentialAndRetry(
 		"timeout", credentialRequestTimeout,
 	)
 
-	// Poll vault with withCredentialRetryCtx so Execute() does not re-enter
-	// this function. Use context.WithoutCancel so the poll survives the tool's
-	// per-call timeout (e.g. vault_github_request timeout_seconds:35) — the
-	// credential wait is user-paced, not API-call-paced. The pollCtx still
-	// carries ctx Values (needed for withCredentialRetryCtx) but is not
-	// cancelled when the tool deadline fires; it has its own 8-minute budget.
-	pollCtx, pollCancel := context.WithTimeout(context.WithoutCancel(ctx), credentialRequestTimeout)
-	defer pollCancel()
+	// Poll vault with withCredentialRetryCtx so Execute() does not re-enter this
+	// function. Two contexts are used deliberately:
+	//
+	//   credWaitCtx — derived from context.Background(), NOT from ctx.
+	//     This gives the poll loop its own 8-minute budget that outlives the
+	//     per-tool timeout (e.g. vault_github_request timeout_seconds:35).
+	//     retryCtx is derived from credWaitCtx so each poll Execute() call
+	//     also survives the tool deadline.
+	//
+	//   ctx (original task/Act context) — still selected in the poll loop.
+	//     This ensures steering interrupts and task cancellation are honoured
+	//     immediately, even though the budget context ignores them.
+	//     Note: cancellation is only detected between polls (not mid-HTTP call),
+	//     so there may be up to one credentialPollInterval + vault round-trip of
+	//     delay after cancellation — acceptable given the user-paced nature of
+	//     this flow.
+	credWaitCtx, credWaitCancel := context.WithTimeout(context.Background(), credentialRequestTimeout)
+	defer credWaitCancel()
+	retryCtx := withCredentialRetryCtx(credWaitCtx)
 	deadline := time.Now().Add(credentialRequestTimeout)
-	retryCtx := withCredentialRetryCtx(pollCtx)
 	for time.Now().Before(deadline) {
 		select {
-		case <-pollCtx.Done():
+		case <-ctx.Done():          // task cancelled or steering interrupt — stop immediately
+			return nil
+		case <-credWaitCtx.Done(): // 8-minute credential wait budget exhausted
 			return nil
 		case <-time.After(credentialPollInterval):
 		}

--- a/agents-component/cmd/agent-process/vault.go
+++ b/agents-component/cmd/agent-process/vault.go
@@ -77,6 +77,12 @@ type VaultExecutor struct {
 	cfg             VaultExecConfig
 	log             *slog.Logger
 
+	// cancelCtx is the task-level context (above per-tool timeouts).
+	// The credential poll loop selects on cancelCtx.Done() so it responds to
+	// steering interrupts and task cancellation but NOT to per-tool deadlines
+	// (e.g. vault_github_request timeout_seconds:40).
+	cancelCtx context.Context
+
 	mu                sync.Mutex
 	pending           map[string]chan types.VaultOperationResult    // requestID → result channel
 	progressCallbacks map[string]func(types.VaultOperationProgress) // requestID → onUpdate; at-most-once
@@ -114,7 +120,7 @@ type agentEnvelope struct {
 //	AEGIS_AGENT_ID  — this agent's identity (injected by Lifecycle Manager)
 //
 // Returns nil (non-fatal) if either env var is absent or NATS is unreachable.
-func NewVaultExecutor(log *slog.Logger, taskID, permissionToken, traceID string) *VaultExecutor {
+func NewVaultExecutor(log *slog.Logger, cancelCtx context.Context, taskID, permissionToken, traceID string) *VaultExecutor {
 	natsURL := os.Getenv("AEGIS_NATS_URL")
 	agentID := os.Getenv("AEGIS_AGENT_ID")
 	if natsURL == "" || agentID == "" {
@@ -153,6 +159,7 @@ func NewVaultExecutor(log *slog.Logger, taskID, permissionToken, traceID string)
 		permissionToken:   permissionToken,
 		cfg:               cfg,
 		log:               log,
+		cancelCtx:         cancelCtx,
 		pending:           make(map[string]chan types.VaultOperationResult),
 		progressCallbacks: make(map[string]func(types.VaultOperationProgress)),
 		credPending:       make(map[string]chan struct{}),
@@ -677,7 +684,7 @@ func (ve *VaultExecutor) requestCredentialAndRetry(
 		case <-doneCh:
 			retried := ve.Execute(withCredentialRetryCtx(ctx), operationType, credentialType, operationParams, timeoutSeconds, onUpdate)
 			return &retried
-		case <-ctx.Done():
+		case <-ve.cancelCtx.Done(): // task cancelled or steering interrupt only
 			return nil
 		case <-timer.C:
 			r := ToolResult{
@@ -758,9 +765,12 @@ func (ve *VaultExecutor) requestCredentialAndRetry(
 	deadline := time.Now().Add(credentialRequestTimeout)
 	for time.Now().Before(deadline) {
 		select {
-		case <-ctx.Done():          // task cancelled or steering interrupt — stop immediately
+		case <-ve.cancelCtx.Done(): // task cancelled or steering interrupt — stop immediately
+			// ve.cancelCtx is the task-level context above per-tool timeouts,
+			// so this fires only on steering directives or explicit cancellation,
+			// not on the per-tool deadline (e.g. vault_github_request 40s).
 			return nil
-		case <-credWaitCtx.Done(): // 8-minute credential wait budget exhausted
+		case <-credWaitCtx.Done(): // 3-minute credential wait budget exhausted
 			return nil
 		case <-time.After(credentialPollInterval):
 		}

--- a/agents-component/cmd/agent-process/vault.go
+++ b/agents-component/cmd/agent-process/vault.go
@@ -77,12 +77,6 @@ type VaultExecutor struct {
 	cfg             VaultExecConfig
 	log             *slog.Logger
 
-	// cancelCtx is the task-level context (above per-tool timeouts).
-	// The credential poll loop selects on cancelCtx.Done() so it responds to
-	// steering interrupts and task cancellation but NOT to per-tool deadlines
-	// (e.g. vault_github_request timeout_seconds:40).
-	cancelCtx context.Context
-
 	mu                sync.Mutex
 	pending           map[string]chan types.VaultOperationResult    // requestID → result channel
 	progressCallbacks map[string]func(types.VaultOperationProgress) // requestID → onUpdate; at-most-once
@@ -120,7 +114,7 @@ type agentEnvelope struct {
 //	AEGIS_AGENT_ID  — this agent's identity (injected by Lifecycle Manager)
 //
 // Returns nil (non-fatal) if either env var is absent or NATS is unreachable.
-func NewVaultExecutor(log *slog.Logger, cancelCtx context.Context, taskID, permissionToken, traceID string) *VaultExecutor {
+func NewVaultExecutor(log *slog.Logger, taskID, permissionToken, traceID string) *VaultExecutor {
 	natsURL := os.Getenv("AEGIS_NATS_URL")
 	agentID := os.Getenv("AEGIS_AGENT_ID")
 	if natsURL == "" || agentID == "" {
@@ -159,7 +153,6 @@ func NewVaultExecutor(log *slog.Logger, cancelCtx context.Context, taskID, permi
 		permissionToken:   permissionToken,
 		cfg:               cfg,
 		log:               log,
-		cancelCtx:         cancelCtx,
 		pending:           make(map[string]chan types.VaultOperationResult),
 		progressCallbacks: make(map[string]func(types.VaultOperationProgress)),
 		credPending:       make(map[string]chan struct{}),
@@ -597,6 +590,35 @@ const (
 	credentialPollInterval   = 8 * time.Second
 )
 
+// credentialCancelCtxKey carries the Act-phase context through the tool context
+// chain so the credential poll loop can respond to steering interrupts without
+// being affected by per-tool timeouts.
+//
+// Usage:
+//
+//	loop.go (before dispatchTool):
+//	  toolCtx = WithCredentialCancelCtx(toolCtx, actCtx)
+//
+//	requestCredentialAndRetry:
+//	  cancelCtx := credentialCancelCtxFrom(ctx)  // extracts actCtx
+type credentialCancelCtxKey struct{}
+
+// WithCredentialCancelCtx embeds cancelCtx as a context value so vault code
+// can retrieve it even after dispatchTool wraps ctx with a per-tool deadline.
+func WithCredentialCancelCtx(ctx, cancelCtx context.Context) context.Context {
+	return context.WithValue(ctx, credentialCancelCtxKey{}, cancelCtx)
+}
+
+// credentialCancelCtxFrom extracts the Act-phase cancel context embedded by
+// WithCredentialCancelCtx. Falls back to ctx itself if no value is present
+// (e.g. in tests or non-credentialed paths).
+func credentialCancelCtxFrom(ctx context.Context) context.Context {
+	if c, ok := ctx.Value(credentialCancelCtxKey{}).(context.Context); ok && c != nil {
+		return c
+	}
+	return ctx
+}
+
 // credentialRetryKey is the context key that marks a vault execute call as
 // originating from inside requestCredentialAndRetry. Execute() skips the
 // MISSING_CREDENTIAL retry path when this key is present, preventing infinite
@@ -684,7 +706,7 @@ func (ve *VaultExecutor) requestCredentialAndRetry(
 		case <-doneCh:
 			retried := ve.Execute(withCredentialRetryCtx(ctx), operationType, credentialType, operationParams, timeoutSeconds, onUpdate)
 			return &retried
-		case <-ve.cancelCtx.Done(): // task cancelled or steering interrupt only
+		case <-credentialCancelCtxFrom(ctx).Done(): // Act-phase cancel (steering interrupt)
 			return nil
 		case <-timer.C:
 			r := ToolResult{
@@ -744,31 +766,28 @@ func (ve *VaultExecutor) requestCredentialAndRetry(
 	)
 
 	// Poll vault with withCredentialRetryCtx so Execute() does not re-enter this
-	// function. Two contexts are used deliberately:
+	// function. Three contexts cooperate:
 	//
-	//   credWaitCtx — derived from context.Background(), NOT from ctx.
-	//     This gives the poll loop its own 8-minute budget that outlives the
-	//     per-tool timeout (e.g. vault_github_request timeout_seconds:35).
-	//     retryCtx is derived from credWaitCtx so each poll Execute() call
-	//     also survives the tool deadline.
+	//   cancelCtx  — the Act-phase context extracted from the tool context value
+	//     chain via credentialCancelCtxFrom. Embedded by loop.go before calling
+	//     dispatchTool so it survives the per-tool WithTimeout wrapper. Cancelled
+	//     only by steering interrupts, not by per-tool timeouts.
 	//
-	//   ctx (original task/Act context) — still selected in the poll loop.
-	//     This ensures steering interrupts and task cancellation are honoured
-	//     immediately, even though the budget context ignores them.
-	//     Note: cancellation is only detected between polls (not mid-HTTP call),
-	//     so there may be up to one credentialPollInterval + vault round-trip of
-	//     delay after cancellation — acceptable given the user-paced nature of
-	//     this flow.
-	credWaitCtx, credWaitCancel := context.WithTimeout(context.Background(), credentialRequestTimeout)
+	//   credWaitCtx — timeout budget for the credential wait. Derived from
+	//     context.WithoutCancel(ctx) so it preserves session/trace values from
+	//     ctx but is not cancelled by the per-tool deadline.
+	//
+	//   retryCtx — passed to each poll Execute() call; carries the retry marker
+	//     (prevents re-entry) and the credential wait budget.
+	cancelCtx := credentialCancelCtxFrom(ctx)
+	credWaitBase := context.WithoutCancel(ctx)
+	credWaitCtx, credWaitCancel := context.WithTimeout(credWaitBase, credentialRequestTimeout)
 	defer credWaitCancel()
 	retryCtx := withCredentialRetryCtx(credWaitCtx)
 	deadline := time.Now().Add(credentialRequestTimeout)
 	for time.Now().Before(deadline) {
 		select {
-		case <-ve.cancelCtx.Done(): // task cancelled or steering interrupt — stop immediately
-			// ve.cancelCtx is the task-level context above per-tool timeouts,
-			// so this fires only on steering directives or explicit cancellation,
-			// not on the per-tool deadline (e.g. vault_github_request 40s).
+		case <-cancelCtx.Done(): // Act-phase cancelled (steering interrupt) — stop immediately
 			return nil
 		case <-credWaitCtx.Done(): // 3-minute credential wait budget exhausted
 			return nil

--- a/agents-component/cmd/agent-process/vault.go
+++ b/agents-component/cmd/agent-process/vault.go
@@ -619,6 +619,20 @@ func credentialCancelCtxFrom(ctx context.Context) context.Context {
 	return ctx
 }
 
+// buildCredentialCtxs constructs the two contexts needed for any credential
+// wait — both the owner poll loop and the duplicate waiter branch use the same
+// pair so neither can be cut short by the per-tool deadline.
+//
+//   cancelCtx — the Act-phase context for steering-interrupt detection.
+//   waitCtx   — timeout budget derived from context.WithoutCancel(ctx) so the
+//               per-tool deadline is stripped while session/trace values are
+//               preserved. Caller must call waitCancel when done.
+func buildCredentialCtxs(ctx context.Context) (cancelCtx, waitCtx context.Context, waitCancel context.CancelFunc) {
+	cancelCtx = credentialCancelCtxFrom(ctx)
+	waitCtx, waitCancel = context.WithTimeout(context.WithoutCancel(ctx), credentialRequestTimeout)
+	return
+}
+
 // credentialRetryKey is the context key that marks a vault execute call as
 // originating from inside requestCredentialAndRetry. Execute() skips the
 // MISSING_CREDENTIAL retry path when this key is present, preventing infinite
@@ -697,18 +711,27 @@ func (ve *VaultExecutor) requestCredentialAndRetry(
 
 	if alreadyPending {
 		// Another goroutine owns the modal — wait for it to finish, then retry.
+		// Use the same context pair as the owner so the per-tool deadline cannot
+		// cut the wait short: cancelCtx for steering interrupts, waitCtx for the
+		// credential budget.
 		ve.log.Info("vault execute: credential request already in progress — waiting",
 			"credential_type", credentialType,
 		)
-		timer := time.NewTimer(credentialRequestTimeout)
-		defer timer.Stop()
+		cancelCtx, waitCtx, waitCancel := buildCredentialCtxs(ctx)
+		defer waitCancel()
 		select {
 		case <-doneCh:
-			retried := ve.Execute(withCredentialRetryCtx(ctx), operationType, credentialType, operationParams, timeoutSeconds, onUpdate)
+			// Owner finished. Check for steering cancellation before retrying.
+			select {
+			case <-cancelCtx.Done():
+				return nil
+			default:
+			}
+			retried := ve.Execute(withCredentialRetryCtx(waitCtx), operationType, credentialType, operationParams, timeoutSeconds, onUpdate)
 			return &retried
-		case <-credentialCancelCtxFrom(ctx).Done(): // Act-phase cancel (steering interrupt)
+		case <-cancelCtx.Done(): // Act-phase cancel (steering interrupt)
 			return nil
-		case <-timer.C:
+		case <-waitCtx.Done(): // budget exhausted while waiting for owner
 			r := ToolResult{
 				Content:        fmt.Sprintf("No %s was provided within %s. Add your API key in Settings and try again.", credentialType, credentialRequestTimeout),
 				IsError:        true,
@@ -766,22 +789,10 @@ func (ve *VaultExecutor) requestCredentialAndRetry(
 	)
 
 	// Poll vault with withCredentialRetryCtx so Execute() does not re-enter this
-	// function. Three contexts cooperate:
-	//
-	//   cancelCtx  — the Act-phase context extracted from the tool context value
-	//     chain via credentialCancelCtxFrom. Embedded by loop.go before calling
-	//     dispatchTool so it survives the per-tool WithTimeout wrapper. Cancelled
-	//     only by steering interrupts, not by per-tool timeouts.
-	//
-	//   credWaitCtx — timeout budget for the credential wait. Derived from
-	//     context.WithoutCancel(ctx) so it preserves session/trace values from
-	//     ctx but is not cancelled by the per-tool deadline.
-	//
-	//   retryCtx — passed to each poll Execute() call; carries the retry marker
-	//     (prevents re-entry) and the credential wait budget.
-	cancelCtx := credentialCancelCtxFrom(ctx)
-	credWaitBase := context.WithoutCancel(ctx)
-	credWaitCtx, credWaitCancel := context.WithTimeout(credWaitBase, credentialRequestTimeout)
+	// function. buildCredentialCtxs provides:
+	//   cancelCtx   — Act-phase context for steering-interrupt detection
+	//   credWaitCtx — 3-minute budget, per-tool deadline stripped, values kept
+	cancelCtx, credWaitCtx, credWaitCancel := buildCredentialCtxs(ctx)
 	defer credWaitCancel()
 	retryCtx := withCredentialRetryCtx(credWaitCtx)
 	deadline := time.Now().Add(credentialRequestTimeout)

--- a/agents-component/cmd/agent-process/vault.go
+++ b/agents-component/cmd/agent-process/vault.go
@@ -581,9 +581,12 @@ func (ve *VaultExecutor) Execute(ctx context.Context, operationType, credentialT
 }
 
 // credentialRequestTimeout is how long requestCredentialAndRetry polls for the
-// user to enter a missing API key via the IO credential modal before giving up.
+// user to enter a missing API key before giving up. The subtask context
+// (timeout_seconds: 300 from the planner) minus ~60s of agent startup gives
+// roughly 4 minutes of actual input window, so 3 minutes here is the
+// intentional user-facing budget.
 const (
-	credentialRequestTimeout = 8 * time.Minute
+	credentialRequestTimeout = 3 * time.Minute
 	credentialPollInterval   = 8 * time.Second
 )
 

--- a/io/surfaces/web/src/App.tsx
+++ b/io/surfaces/web/src/App.tsx
@@ -1761,10 +1761,25 @@ function App() {
 
         const topTaskId = credRequest.taskId
         if (result.ok) {
-          setCredentialRequests(prev => ({
-            ...prev,
-            [reqId]: { ...prev[reqId], status: 'submitted' },
-          }))
+          // Mark this card submitted AND collapse any duplicate cards for the
+          // same (taskId, keyName) — multiple agents can independently request
+          // the same credential type; once one is stored the others will pick
+          // it up on their next poll, so the duplicate UI cards can be cleared.
+          setCredentialRequests(prev => {
+            const updated = { ...prev }
+            Object.keys(updated).forEach(id => {
+              const entry = updated[id]
+              if (
+                entry.status === 'pending' &&
+                entry.request.taskId === topTaskId &&
+                entry.request.keyName === credRequest.keyName
+              ) {
+                updated[id] = { ...entry, status: 'submitted' }
+              }
+            })
+            updated[reqId] = { ...updated[reqId], status: 'submitted' }
+            return updated
+          })
 
           const sysMsg: ChatMessage = {
             id: nextId(),

--- a/io/surfaces/web/src/App.tsx
+++ b/io/surfaces/web/src/App.tsx
@@ -786,10 +786,11 @@ function App() {
     if (!useMockHeartbeat) return
     if (selectedTaskId !== '13') return
     setCredentialRequests(prev => {
-      if (prev['13']) return prev
+      const reqId = FALLBACK_TASK_13_CREDENTIAL.requestId
+      if (prev[reqId]) return prev
       return {
         ...prev,
-        '13': { request: FALLBACK_TASK_13_CREDENTIAL, status: 'pending' },
+        [reqId]: { request: FALLBACK_TASK_13_CREDENTIAL, status: 'pending' },
       }
     })
   }, [DEMO_MODE, useMockHeartbeat, selectedTaskId])

--- a/io/surfaces/web/src/App.tsx
+++ b/io/surfaces/web/src/App.tsx
@@ -743,16 +743,10 @@ function App() {
         setTaskHeartbeats(prev => ({ ...prev, [p.taskId]: Date.now() }))
       } else if (ev.type === 'credential_request') {
         setCredentialRequests(prev => {
-          const ex = prev[ev.payload.taskId]
-          if (
-            ex?.status === 'submitted' &&
-            ex.request.requestId === ev.payload.requestId
-          ) {
-            return prev
-          }
+          if (prev[ev.payload.requestId]?.status === 'submitted') return prev
           return {
             ...prev,
-            [ev.payload.taskId]: { request: ev.payload, status: 'pending' },
+            [ev.payload.requestId]: { request: ev.payload, status: 'pending' },
           }
         })
       } else if (ev.type === 'plan_preview') {
@@ -1740,99 +1734,74 @@ function App() {
 
   // ── Credential handlers (completely separate from chat) ──
 
-  const selectedTaskCredential = selectedTask
-    ? selectedTask.currentTaskId
-      ? credentialRequests[selectedTask.currentTaskId] ?? null
-      : null
-    : null
-
-  const handleOpenCredentialModal = useCallback(() => {
-    if (!selectedTask?.currentTaskId) return
-    setActiveCredentialTaskId(selectedTask.currentTaskId)
-    setShowCredentialModal(true)
-  }, [selectedTask])
+  type CredentialEntry = { request: CredentialRequest; status: CredentialRequestStatus }
 
   const handleCredentialSubmit = useCallback(
-    async (requestId: string, _credential: string) => {
-      const taskId = activeCredentialTaskId
-      if (!taskId) return
+    async (_requestId: string, _credential: string) => {
+      // Inline cards pass the requestId directly; modal path uses activeCredentialTaskId.
+      const reqId = _requestId || activeCredentialTaskId
+      if (!reqId) return
 
-      const credRequest = credentialRequests[taskId]?.request
+      const credRequest = credentialRequests[reqId]?.request
       if (!credRequest) return
 
       setCredentialRequests(prev => ({
         ...prev,
-        [taskId]: { ...prev[taskId], status: 'submitting' },
+        [reqId]: { ...prev[reqId], status: 'submitting' },
       }))
 
-      const result = await submitCredential({
-        taskId,
-        requestId,
-        userId: credRequest.userId,
-        keyName: credRequest.keyName,
-        value: _credential,
-      })
+      try {
+        const result = await submitCredential({
+          taskId: credRequest.taskId,
+          requestId: reqId,
+          userId: credRequest.userId,
+          keyName: credRequest.keyName,
+          value: _credential,
+        })
 
-      if (result.ok) {
-        setCredentialRequests(prev => ({
-          ...prev,
-          [taskId]: { ...prev[taskId], status: 'submitted' },
-        }))
+        const topTaskId = credRequest.taskId
+        if (result.ok) {
+          setCredentialRequests(prev => ({
+            ...prev,
+            [reqId]: { ...prev[reqId], status: 'submitted' },
+          }))
 
-        // Add a system-level message (no content leaked)
-        const sysMsg: ChatMessage = {
-          id: nextId(),
-          role: 'user',
-          content: 'Credential provided securely via isolated channel',
-          timestamp: timeLabel(),
-          isRedacted: true,
-        }
-        setTasks(prev =>
-          prev.map(t =>
-            t.currentTaskId === taskId ? { ...t, messages: [...t.messages, sysMsg] } : t
-          )
-        )
-
-        if (uiSettings.showActivityLog) {
-          addLogEntry({
-            type: 'status_change',
-            taskId,
-            taskTitle: tasks.find(t => t.currentTaskId === taskId)?.title.slice(0, 20) ?? '',
-            message: 'Credential submitted through secure channel (content not logged)',
-          })
-        }
-
-        // Simulate the orchestrator acknowledging receipt after a short delay
-        setTimeout(() => {
-          const ackMsg: ChatMessage = {
+          const sysMsg: ChatMessage = {
             id: nextId(),
-            role: 'agent',
-            content: 'Credentials received securely. Running the migration now — I\'ll update you when it completes.',
+            role: 'user',
+            content: 'Credential provided securely via isolated channel',
             timestamp: timeLabel(),
+            isRedacted: true,
           }
           setTasks(prev =>
             prev.map(t =>
-              t.currentTaskId === taskId
-                ? {
-                    ...t,
-                    status: 'working',
-                    lastUpdate: 'Running production migration…',
-                    expectedNextInput: '~3 min',
-                    messages: [...t.messages, ackMsg],
-                  }
-                : t
+              t.currentTaskId === topTaskId ? { ...t, messages: [...t.messages, sysMsg] } : t
             )
           )
-        }, 800)
-      } else {
+
+          if (uiSettings.showActivityLog) {
+            addLogEntry({
+              type: 'status_change',
+              taskId: topTaskId,
+              taskTitle: tasks.find(t => t.currentTaskId === topTaskId)?.title.slice(0, 20) ?? '',
+              message: 'Credential submitted through secure channel (content not logged)',
+            })
+          }
+        } else {
+          setCredentialRequests(prev => ({
+            ...prev,
+            [reqId]: { ...prev[reqId], status: 'error' },
+          }))
+        }
+      } catch {
         setCredentialRequests(prev => ({
           ...prev,
-          [taskId]: { ...prev[taskId], status: 'error' },
+          [reqId]: { ...prev[reqId], status: 'error' },
         }))
+      } finally {
+        setShowCredentialModal(false)
+        setActiveCredentialTaskId(null)
       }
-
-      setShowCredentialModal(false)
-      setActiveCredentialTaskId(null)
     },
     [activeCredentialTaskId, credentialRequests, tasks, uiSettings.showActivityLog, addLogEntry]
   )
@@ -2006,9 +1975,22 @@ function App() {
               isStreaming={streamingForTaskId === selectedTask.id}
               streamingContent={streamingForTaskId === selectedTask.id ? streamingContent : ''}
               settings={uiSettings}
-              credentialRequest={selectedTaskCredential?.request}
-              credentialStatus={selectedTaskCredential?.status}
-              onProvideCredential={handleOpenCredentialModal}
+              pendingCredentials={
+                selectedTask.currentTaskId
+                  ? (Object.entries(credentialRequests) as Array<[string, CredentialEntry]>)
+                      .filter(([, v]) => v.request.taskId === selectedTask.currentTaskId && v.status !== 'error')
+                      .map(([reqId, v]) => ({
+                        request: v.request,
+                        status: v.status,
+                        onProvide: () => {
+                          setActiveCredentialTaskId(reqId)
+                          setShowCredentialModal(true)
+                        },
+                        onSubmitInline: (_requestId: string, value: string) =>
+                          handleCredentialSubmit(_requestId, value),
+                      }))
+                  : []
+              }
               pulseMessageKey={liveLogPulseKeyByTask[selectedTask.id] ?? undefined}
               inputPlaceholder={
                 recurringSetup?.conversationId === selectedTask.id

--- a/io/surfaces/web/src/components/ChatWindow.css
+++ b/io/surfaces/web/src/components/ChatWindow.css
@@ -253,6 +253,22 @@
   letter-spacing: 0.05em;
 }
 
+.credential-panel {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  padding: 10px 16px;
+  background-color: var(--bg-primary);
+  border-top: var(--border-subtle);
+}
+
+.credential-panel > * {
+  flex: 1;
+  min-width: 0;
+  max-width: unset;
+  align-self: unset;
+}
+
 .chat-input-area {
   background-color: var(--bg-primary);
   border-top: var(--border);

--- a/io/surfaces/web/src/components/ChatWindow.tsx
+++ b/io/surfaces/web/src/components/ChatWindow.tsx
@@ -15,14 +15,26 @@ function MarkdownContent({ content }: { content: string }) {
   return <div className="message-text markdown-body" dangerouslySetInnerHTML={{ __html: html }} />
 }
 
+interface PendingCredential {
+  request: CredentialRequest
+  status: CredentialRequestStatus
+  onProvide: () => void
+  onSubmitInline?: (requestId: string, value: string) => void | Promise<void>
+}
+
 interface ChatWindowProps {
   task: Task
   onSendMessage: (taskId: string, content: string) => void | Promise<void>
   isStreaming: boolean
   streamingContent: string
   settings: UISettings
+  /** All pending credentials for this task — each gets its own inline card. */
+  pendingCredentials?: PendingCredential[]
+  /** @deprecated use pendingCredentials */
   credentialRequest?: CredentialRequest | null
+  /** @deprecated use pendingCredentials */
   credentialStatus?: CredentialRequestStatus
+  /** @deprecated use pendingCredentials */
   onProvideCredential?: () => void
   /** Rendered below the transcript, above the composer (e.g. recurring schedule panel). */
   belowMessages?: ReactNode
@@ -47,6 +59,7 @@ function ChatWindow({
   isStreaming,
   streamingContent,
   settings,
+  pendingCredentials = [],
   credentialRequest,
   credentialStatus,
   onProvideCredential,
@@ -56,6 +69,12 @@ function ChatWindow({
   inputPlaceholder,
   pulseMessageKey,
 }: ChatWindowProps) {
+  // Merge legacy single-credential prop into the array for backwards compat.
+  const allCredentials: PendingCredential[] = pendingCredentials.length > 0
+    ? pendingCredentials
+    : (credentialRequest && credentialStatus && onProvideCredential
+        ? [{ request: credentialRequest, status: credentialStatus, onProvide: onProvideCredential }]
+        : [])
   const [inputValue, setInputValue] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
@@ -150,14 +169,6 @@ function ChatWindow({
           </div>
         ))}
 
-        {credentialRequest && credentialStatus && onProvideCredential && (
-          <CredentialRequestCard
-            request={credentialRequest}
-            status={credentialStatus}
-            onProvide={onProvideCredential}
-          />
-        )}
-
         {isStreaming && (
           <div className="message agent streaming">
             <div className="message-avatar"><span className="avatar-glyph">C</span></div>
@@ -182,6 +193,20 @@ function ChatWindow({
       </div>
 
       {belowMessages}
+
+      {allCredentials.length > 0 && (
+        <div className="credential-panel">
+          {allCredentials.map(c => (
+            <CredentialRequestCard
+              key={c.request.requestId}
+              request={c.request}
+              status={c.status}
+              onProvide={c.onProvide}
+              onSubmitInline={c.onSubmitInline}
+            />
+          ))}
+        </div>
+      )}
 
       <div className="chat-input-area">
         {settings.demoMode && !isStreaming && !composerDisabled && !(task.title === 'New Task' && task.messages.length === 0) && (

--- a/io/surfaces/web/src/components/CredentialRequestCard.css
+++ b/io/surfaces/web/src/components/CredentialRequestCard.css
@@ -79,3 +79,62 @@
   cursor: not-allowed;
   color: var(--text-muted);
 }
+
+/* Inline input variant */
+.cred-card-inline {
+  align-items: flex-start;
+  max-width: 90%;
+  border: var(--border-subtle);
+}
+
+.cred-card-body-expanded {
+  gap: var(--sp-2);
+}
+
+.cred-card-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  margin-top: 2px;
+}
+
+.cred-card-input-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.cred-card-input {
+  flex: 1;
+  background: var(--input-bg, rgba(255,255,255,0.06));
+  border: 1px solid var(--border-color, rgba(255,255,255,0.12));
+  border-radius: var(--radius-xs);
+  color: var(--text-primary);
+  font-size: 12px;
+  padding: 5px var(--sp-2);
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+.cred-card-input:focus {
+  border-color: var(--accent-border);
+}
+
+.cred-card-input:disabled {
+  opacity: 0.4;
+}
+
+.cred-card-eye-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 13px;
+  opacity: 0.5;
+  padding: 2px 4px;
+  color: var(--text-primary);
+  flex-shrink: 0;
+}
+
+.cred-card-eye-btn:hover {
+  opacity: 0.8;
+}

--- a/io/surfaces/web/src/components/CredentialRequestCard.tsx
+++ b/io/surfaces/web/src/components/CredentialRequestCard.tsx
@@ -1,3 +1,4 @@
+import { useState, useRef } from 'react'
 import type { CredentialRequest, CredentialRequestStatus } from '@cerberos/io-core'
 import './CredentialRequestCard.css'
 
@@ -5,9 +6,15 @@ interface CredentialRequestCardProps {
   request: CredentialRequest
   status: CredentialRequestStatus
   onProvide: () => void
+  /** When provided, renders an inline input instead of opening a modal. */
+  onSubmitInline?: (requestId: string, value: string) => void | Promise<void>
 }
 
-function CredentialRequestCard({ request, status, onProvide }: CredentialRequestCardProps) {
+function CredentialRequestCard({ request, status, onProvide, onSubmitInline }: CredentialRequestCardProps) {
+  const [value, setValue] = useState('')
+  const [reveal, setReveal] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
   if (status === 'submitted') {
     return (
       <div className="cred-card cred-card-done">
@@ -15,6 +22,58 @@ function CredentialRequestCard({ request, status, onProvide }: CredentialRequest
         <div className="cred-card-body">
           <span className="cred-card-title">Credential provided securely</span>
           <span className="cred-card-subtitle">{request.label}</span>
+        </div>
+      </div>
+    )
+  }
+
+  if (onSubmitInline) {
+    const handleSubmit = (e: React.FormEvent) => {
+      e.preventDefault()
+      if (!value.trim() || status === 'submitting') return
+      onSubmitInline(request.requestId, value.trim())
+    }
+
+    return (
+      <div className="cred-card cred-card-inline">
+        <div className="cred-card-icon">{'\u{1F512}'}</div>
+        <div className="cred-card-body cred-card-body-expanded">
+          <span className="cred-card-title">{request.label}</span>
+          {request.description && (
+            <span className="cred-card-subtitle">{request.description}</span>
+          )}
+          <form onSubmit={handleSubmit} className="cred-card-form">
+            <div className="cred-card-input-row">
+              <input
+                ref={inputRef}
+                type={reveal ? 'text' : 'password'}
+                value={value}
+                onChange={e => setValue(e.target.value)}
+                placeholder="Enter credential…"
+                className="cred-card-input"
+                autoComplete="off"
+                spellCheck={false}
+                disabled={status === 'submitting'}
+              />
+              <button
+                type="button"
+                className="cred-card-eye-btn"
+                onMouseDown={() => setReveal(true)}
+                onMouseUp={() => setReveal(false)}
+                onMouseLeave={() => setReveal(false)}
+                tabIndex={-1}
+              >
+                {reveal ? '\u{1F441}' : '\u{1F441}\u{200D}\u{1F5E8}'}
+              </button>
+            </div>
+            <button
+              type="submit"
+              className="cred-card-btn"
+              disabled={!value.trim() || status === 'submitting'}
+            >
+              {status === 'submitting' ? 'Submitting…' : '\u{1F512} Submit securely'}
+            </button>
+          </form>
         </div>
       </div>
     )

--- a/io/surfaces/web/src/components/CredentialRequestCard.tsx
+++ b/io/surfaces/web/src/components/CredentialRequestCard.tsx
@@ -30,8 +30,8 @@ function CredentialRequestCard({ request, status, onProvide, onSubmitInline }: C
   if (onSubmitInline) {
     const handleSubmit = (e: React.FormEvent) => {
       e.preventDefault()
-      if (!value.trim() || status === 'submitting') return
-      onSubmitInline(request.requestId, value.trim())
+      if (!value || status === 'submitting') return
+      onSubmitInline(request.requestId, value)
     }
 
     return (
@@ -69,7 +69,7 @@ function CredentialRequestCard({ request, status, onProvide, onSubmitInline }: C
             <button
               type="submit"
               className="cred-card-btn"
-              disabled={!value.trim() || status === 'submitting'}
+              disabled={!value || status === 'submitting'}
             >
               {status === 'submitting' ? 'Submitting…' : '\u{1F512} Submit securely'}
             </button>

--- a/orchestrator/internal/dispatcher/dispatcher.go
+++ b/orchestrator/internal/dispatcher/dispatcher.go
@@ -1531,12 +1531,13 @@ func buildDecompositionInstructionsWithFacts(taskID, rawInput string, scope type
 		"Decompose the user's task into a JSON execution plan for downstream agents.\n"+
 			"Return JSON only. Do not wrap the result in markdown fences. Do not include commentary.\n"+
 			"The JSON schema is:\n"+
-			"{\"plan_id\":\"string\",\"parent_task_id\":\"%s\",\"created_at\":\"RFC3339 timestamp\",\"subtasks\":[{\"subtask_id\":\"string\",\"required_skill_domains\":[\"domain\"],\"action\":\"string\",\"instructions\":\"string\",\"params\":{},\"depends_on\":[\"subtask_id\"],\"timeout_seconds\":30}]}\n"+
+			"{\"plan_id\":\"string\",\"parent_task_id\":\"%s\",\"created_at\":\"RFC3339 timestamp\",\"subtasks\":[{\"subtask_id\":\"string\",\"required_skill_domains\":[\"domain\"],\"action\":\"string\",\"instructions\":\"string\",\"params\":{},\"depends_on\":[\"subtask_id\"],\"timeout_seconds\":300}]}\n"+
 			"Rules:\n"+
 			"- parent_task_id must equal %q\n"+
 			"- required_skill_domains for every subtask must be a subset of %s\n"+
 			"- Do not invent new skill domain names outside the allowed list\n"+
 			"- Use an empty array for depends_on when a subtask has no dependencies\n"+
+			"- timeout_seconds MUST be 300 for every subtask — never use a lower value\n"+
 			"- Keep the plan concise and executable\n"+
 			"Skill domain guide: use \"web\" for fetch/parse/extract of known URLs AND for AI web search (web.web_search via Tavily, no Google account needed), \"data\" for transforms/reads/writes, \"comms\" for messaging, \"storage\" for file operations, \"logs\" for log queries, \"google_search\" for explicitly Google-API-backed search, \"github\" for GitHub API calls, \"local_files\" for reading/writing files in the user's home (notes, journal, etc. — paths starting with ~/ map to per-user storage), \"general\" for reasoning/summarization with no external tools.\n"+
 			"- For ANY task that requires real-world or current information (events this weekend, weather, news, prices, hours, addresses, etc.), include AT LEAST one subtask in the \"web\" domain — web.web_search composes well across topics.\n"+

--- a/vault/engine/handlers/execute/ops.go
+++ b/vault/engine/handlers/execute/ops.go
@@ -110,6 +110,9 @@ func execGoogleSearch(ctx context.Context, credential string, params map[string]
 // execGitHubRequest makes an authenticated GitHub REST API request.
 // credential is the GitHub personal access token. params must include "path".
 func execGitHubRequest(ctx context.Context, credential string, params map[string]any) opResult {
+	if credential == "" {
+		return opResult{err: fmt.Errorf("github_token is required"), code: ErrCodeCredentialUnavailable}
+	}
 	path, ok := params["path"].(string)
 	if !ok || path == "" {
 		return opResult{err: fmt.Errorf("path parameter is required"), code: ErrCodeInvalidParams}


### PR DESCRIPTION
## Summary

- **Credentials no longer block each other** — re-keyed `credentialRequests` map by
  `requestId` instead of `taskId`, so two concurrent credentials for the same task
  no longer overwrite each other in state
- **Both credential inputs appear simultaneously** — all pending credentials are
  passed as an array to `ChatWindow` and rendered as side-by-side inline cards
  pinned above the composer (never scrolls out of view)
- **Inline input replaces the modal** — `CredentialRequestCard` now renders a
  password input and submit button directly in the card; no modal, no queue,
  no focus-stealing between sibling cards
- **Credential poll loop survives tool timeouts** — `vault.go` uses
  `context.WithoutCancel` so the 8-minute credential wait is not cut short
  by the per-skill `timeout_seconds` (e.g. `vault_github_request` has 35s)
- **Planner forced to 300s subtask timeouts** — explicit rule added to planner
  prompt; LLM was generating 30s timeouts that killed the poll loop before
  the user could enter credentials
- **GitHub handler rejects empty credentials** — `execGitHubRequest` now returns
  `CREDENTIAL_UNAVAILABLE` immediately on empty token instead of forwarding
  `Authorization: Bearer ` to GitHub, which silently served public repos and
  bypassed the credential modal

## Changes

| File | Change |
|---|---|
| `agents-component/cmd/agent-process/vault.go` | `context.WithoutCancel` for credential poll loop |
| `orchestrator/internal/dispatcher/dispatcher.go` | Force 300s subtask timeout; tighten Google trigger phrases |
| `vault/engine/handlers/execute/ops.go` | Guard `execGitHubRequest` against empty credential |
| `io/surfaces/web/src/App.tsx` | Re-key by `requestId`; pass `pendingCredentials` array; `try/finally` on submit; filter includes `submitted`/`submitting` |
| `io/surfaces/web/src/components/ChatWindow.tsx` | Move credential cards to fixed panel above input |
| `io/surfaces/web/src/components/ChatWindow.css` | Fixed panel as horizontal flex row |
| `io/surfaces/web/src/components/CredentialRequestCard.tsx` | Inline input form; remove focus-stealing `useEffect` |
| `io/surfaces/web/src/components/CredentialRequestCard.css` | Inline form styles |

## Before / After

**Before:** One credential modal appeared at a time. Submitting the first
auto-advanced the modal to the second. The modal often failed to close
(missing `try/finally`). The credential poll loop timed out after ~35 seconds
(killed by the tool's `timeout_seconds`), causing the agent to give up before
the user could enter the credential.

**After:** Both credential input cards appear side by side above the composer.
The user fills in each independently in any order. Submitting one does not
affect the other. The poll loop waits the full 8 minutes regardless of skill
timeout.

## Test plan

- [ ] Send a task requiring two credentials (e.g. Google search + GitHub repos)
- [ ] Verify both inline cards appear side by side above the input box
- [ ] Fill in either card first — confirm focus is not stolen by the other card
- [ ] Submit each card — card collapses to ✅ confirmation, other card unaffected
- [ ] Delay entering credentials for 2+ minutes — confirm agent is still waiting
- [ ] Verify GitHub subtask correctly shows credential modal when `github_token`
      is missing (not silently using public repo access)
