### PR TITLE
feat(time): localise agent wall-clock to the user's browser tz

### DIFF
--- a/agents-component/cmd/agent-process/loop.go
+++ b/agents-component/cmd/agent-process/loop.go
@@ -185,7 +185,7 @@ func RunLoop(ctx context.Context, log *slog.Logger, spawnCtx *SpawnContext, ve *
 	// spawn_agent) are never evicted.
 	tools = applySpecBudget(budget, spawnCtx.SkillDomain, tools, log)
 	toolDefs := toolDefinitions(tools)
-	systemPrompt := buildSystemPrompt(spawnCtx.SkillDomain, spawnCtx.CommandManifest, spawnCtx.AgentMemory, spawnCtx.UserProfile)
+	systemPrompt := buildSystemPrompt(spawnCtx.SkillDomain, spawnCtx.CommandManifest, spawnCtx.AgentMemory, spawnCtx.UserProfile, spawnCtx.UserTimezone)
 
 	// Build conversation history. When priorTurns is non-nil the turns from the
 	// previous task in this conversation are prepended so the LLM sees the full
@@ -653,21 +653,56 @@ func contextWindowAction(totalTokens int64) contextAction {
 // agentMemory and userProfile are injected as read-only context sections when
 // non-empty. They are excluded from the spawn context token budget because they
 // are system overhead, not task payload.
-func buildSystemPrompt(skillDomain, manifest, agentMemory, userProfile string) string {
+func buildSystemPrompt(skillDomain, manifest, agentMemory, userProfile, userTimezone string) string {
 	// Prepend today's date so the LLM resolves relative phrases ("tomorrow",
 	// "next Monday", "this weekend") against the host's wall-clock instead of
 	// its own training-cutoff prior. Without this, models silently default to
 	// dates near their cutoff (e.g. early 2025) when the user actually means
 	// something in 2026 — most visibly in calendar invites and scheduling.
-	now := time.Now()
+	//
+	// userTimezone is the IANA tz name from the user's browser (e.g.
+	// "America/Los_Angeles"). If empty or unparseable, fall back to UTC. Both
+	// the wall-clock and the explicit "report times in this tz" instruction
+	// keep the LLM from defaulting to UTC in user-facing replies (the iCal
+	// feed and most internal timestamps are UTC).
+	now := time.Now().UTC()
+	loc := time.UTC
+	tzLabel := "UTC"
+	if userTimezone != "" {
+		if parsed, err := time.LoadLocation(userTimezone); err == nil {
+			loc = parsed
+			tzLabel = userTimezone
+		}
+	}
+	localNow := now.In(loc)
+	// Build a worked example so the LLM knows EXACTLY what conversion + format
+	// is expected. Without an example the model tends to echo the raw ISO
+	// timestamp it gets back from tool results (calendar feeds, vault ops)
+	// instead of converting and humanising.
+	exampleUTC := time.Date(2026, 1, 15, 22, 30, 0, 0, time.UTC)
+	exampleLocal := exampleUTC.In(loc)
 	header := fmt.Sprintf(
-		"Today's date is %s (%s). The current local time is %s. "+
-			"Resolve any relative date or time references in the user's request "+
-			"(\"tomorrow\", \"next week\", \"in two hours\") against this clock — "+
-			"never against your training cutoff.\n\n",
-		now.Format("Monday, January 2, 2006"),
-		now.Format("2006-01-02"),
-		now.Format("15:04 MST"),
+		"Today's date is %s (%s). The current time is %s (%s UTC). "+
+			"User timezone: %s.\n\n"+
+			"TIME HANDLING RULES (MANDATORY):\n"+
+			"1. Resolve relative time references in the user's request "+
+			"(\"tomorrow\", \"next week\", \"in two hours\") against the clock above — "+
+			"never against your training cutoff.\n"+
+			"2. Tool results often contain ISO 8601 UTC timestamps (e.g. \"2026-05-13T05:32:00Z\"). "+
+			"You MUST convert those to %s before showing them to the user. "+
+			"Never echo a raw \"...Z\" timestamp in a user-facing reply.\n"+
+			"3. Format converted times as a human-friendly string with the tz abbreviation, "+
+			"e.g. \"%s\" — NOT as an ISO string.\n"+
+			"4. Worked example: a tool returns \"%s\". You report it as \"%s\".\n\n",
+		localNow.Format("Monday, January 2, 2006"),
+		localNow.Format("2006-01-02"),
+		localNow.Format("15:04 MST"),
+		now.Format("15:04"),
+		tzLabel,
+		tzLabel,
+		localNow.Format("Monday, January 2 at 3:04 PM MST"),
+		exampleUTC.Format("2006-01-02T15:04:05Z"),
+		exampleLocal.Format("Thursday, January 15 at 3:04 PM MST"),
 	)
 
 	var base string

--- a/agents-component/cmd/agent-process/loop_test.go
+++ b/agents-component/cmd/agent-process/loop_test.go
@@ -82,7 +82,7 @@ func TestContextWindowAction_JustBelowCompact(t *testing.T) {
 
 func TestBuildSystemPrompt_General_IgnoresManifest(t *testing.T) {
 	// "general" domain returns a fixed prompt regardless of manifest content.
-	got := buildSystemPrompt("general", "- some_tool: does something\n", "", "")
+	got := buildSystemPrompt("general", "- some_tool: does something\n", "", "", "")
 	if strings.Contains(got, "Available commands") {
 		t.Error("general domain prompt must not include command manifest")
 	}
@@ -93,7 +93,7 @@ func TestBuildSystemPrompt_General_IgnoresManifest(t *testing.T) {
 
 func TestBuildSystemPrompt_Domain_NoManifest(t *testing.T) {
 	// An empty manifest should produce the base prompt with no manifest section.
-	got := buildSystemPrompt("web", "", "", "")
+	got := buildSystemPrompt("web", "", "", "", "")
 	if strings.Contains(got, "Available commands") {
 		t.Errorf("empty manifest: prompt must not include 'Available commands' section; got %q", got)
 	}
@@ -104,7 +104,7 @@ func TestBuildSystemPrompt_Domain_NoManifest(t *testing.T) {
 
 func TestBuildSystemPrompt_Domain_WithManifest(t *testing.T) {
 	manifest := "- web_fetch: Fetches a webpage by URL.\n- web_parse: Parses HTML into text.\n"
-	got := buildSystemPrompt("web", manifest, "", "")
+	got := buildSystemPrompt("web", manifest, "", "", "")
 	if !strings.Contains(got, "Available commands:") {
 		t.Errorf("prompt with manifest must include 'Available commands:' header; got %q", got)
 	}
@@ -118,7 +118,7 @@ func TestBuildSystemPrompt_Domain_WithManifest(t *testing.T) {
 
 func TestBuildSystemPrompt_ManifestAppendsAfterBase(t *testing.T) {
 	manifest := "- web_fetch: Fetches a webpage.\n"
-	got := buildSystemPrompt("web", manifest, "", "")
+	got := buildSystemPrompt("web", manifest, "", "", "")
 	// Manifest must come after the base instructional text, not before.
 	baseIdx := strings.Index(got, "task_complete")
 	manifestIdx := strings.Index(got, "Available commands:")
@@ -135,7 +135,7 @@ func TestBuildSystemPrompt_ManifestAppendsAfterBase(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestBuildSystemPrompt_WithAgentMemory_InjectsSection(t *testing.T) {
-	got := buildSystemPrompt("web", "", "The target API returns ISO8601 timestamps.", "")
+	got := buildSystemPrompt("web", "", "The target API returns ISO8601 timestamps.", "", "")
 	if !strings.Contains(got, "## Knowledge from past tasks") {
 		t.Error("agentMemory: expected '## Knowledge from past tasks' section header")
 	}
@@ -145,7 +145,7 @@ func TestBuildSystemPrompt_WithAgentMemory_InjectsSection(t *testing.T) {
 }
 
 func TestBuildSystemPrompt_WithUserProfile_InjectsSection(t *testing.T) {
-	got := buildSystemPrompt("web", "", "", "User prefers concise bullet points.")
+	got := buildSystemPrompt("web", "", "", "User prefers concise bullet points.", "")
 	if !strings.Contains(got, "## User context") {
 		t.Error("userProfile: expected '## User context' section header")
 	}
@@ -155,7 +155,7 @@ func TestBuildSystemPrompt_WithUserProfile_InjectsSection(t *testing.T) {
 }
 
 func TestBuildSystemPrompt_WithBoth_BothSectionsPresent(t *testing.T) {
-	got := buildSystemPrompt("web", "", "API fact.", "User pref.")
+	got := buildSystemPrompt("web", "", "API fact.", "User pref.", "")
 	if !strings.Contains(got, "## Knowledge from past tasks") {
 		t.Error("both: expected knowledge section")
 	}
@@ -165,7 +165,7 @@ func TestBuildSystemPrompt_WithBoth_BothSectionsPresent(t *testing.T) {
 }
 
 func TestBuildSystemPrompt_EmptyMemory_NoSectionsAdded(t *testing.T) {
-	got := buildSystemPrompt("web", "- cmd: desc.", "", "")
+	got := buildSystemPrompt("web", "- cmd: desc.", "", "", "")
 	if strings.Contains(got, "## Knowledge") {
 		t.Error("empty agentMemory must not produce knowledge section")
 	}
@@ -176,7 +176,7 @@ func TestBuildSystemPrompt_EmptyMemory_NoSectionsAdded(t *testing.T) {
 
 func TestBuildSystemPrompt_MemorySectionsAfterManifest(t *testing.T) {
 	manifest := "- web_fetch: Fetches.\n"
-	got := buildSystemPrompt("web", manifest, "fact", "pref")
+	got := buildSystemPrompt("web", manifest, "fact", "pref", "")
 	manifestIdx := strings.Index(got, "Available commands:")
 	memIdx := strings.Index(got, "## Knowledge from past tasks")
 	if manifestIdx < 0 || memIdx < 0 {
@@ -189,7 +189,7 @@ func TestBuildSystemPrompt_MemorySectionsAfterManifest(t *testing.T) {
 
 func TestBuildSystemPrompt_General_WithMemory_SectionsAppended(t *testing.T) {
 	// General domain still gets memory sections even though it has no manifest.
-	got := buildSystemPrompt("general", "", "stored fact", "")
+	got := buildSystemPrompt("general", "", "stored fact", "", "")
 	if !strings.Contains(got, "general-purpose") {
 		t.Error("general domain base text must be present")
 	}

--- a/agents-component/cmd/agent-process/main.go
+++ b/agents-component/cmd/agent-process/main.go
@@ -54,6 +54,12 @@
 package main
 
 import (
+	// Embed the IANA timezone database so time.LoadLocation works inside
+	// scratch / alpine containers that don't ship /usr/share/zoneinfo.
+	// Without this, buildSystemPrompt silently falls back to UTC even when
+	// the user's browser sent a valid IANA tz like "America/Los_Angeles".
+	_ "time/tzdata"
+
 	"context"
 	"encoding/json"
 	"errors"
@@ -110,6 +116,12 @@ type SpawnContext struct {
 	// non-user-facing helpers (planner, intermediate executors) cannot poison the
 	// conversation history with their orchestrator-generated user instructions.
 	UserFacing bool `json:"user_facing,omitempty"`
+
+	// UserTimezone is the IANA tz name detected from the user's browser
+	// (e.g. "America/Los_Angeles"). Empty falls back to UTC. Used by
+	// buildSystemPrompt to localise the wall-clock header so the LLM both
+	// resolves and reports times in the user's tz.
+	UserTimezone string `json:"user_timezone,omitempty"`
 }
 
 // TaskOutput is the result written to stdout when the task completes or fails.

--- a/agents-component/internal/factory/factory.go
+++ b/agents-component/internal/factory/factory.go
@@ -488,6 +488,7 @@ func (f *Factory) provision(agentID string, spec *types.TaskSpec) error {
 	userProfile := f.fetchUserProfile(spec.UserContextID, spec.TraceID)
 	priorTurns, _ := f.fetchPriorTurns(spec.ConversationID, spec.TraceID)
 	originalUserMessage, userFacing := extractConversationMetadata(spec)
+	userTimezone := extractUserTimezone(spec)
 
 	// Step 6: Spawn agent process.
 	vmCfg := lifecycle.VMConfig{
@@ -507,6 +508,7 @@ func (f *Factory) provision(agentID string, spec *types.TaskSpec) error {
 		SynthesizedSkills:   f.synthesizedSkillsForDomain(entryDomain),
 		OriginalUserMessage: originalUserMessage,
 		UserFacing:          userFacing,
+		UserTimezone:        userTimezone,
 		OnComplete:          f.processCompletionHandler(agentID),
 	}
 	if err := f.lifecycle.Spawn(vmCfg); err != nil {
@@ -610,6 +612,7 @@ func (f *Factory) assignTask(agentID string, spec *types.TaskSpec) error {
 	userProfile := f.fetchUserProfile(spec.UserContextID, spec.TraceID)
 	priorTurns, _ := f.fetchPriorTurns(spec.ConversationID, spec.TraceID)
 	originalUserMessage, userFacing := extractConversationMetadata(spec)
+	userTimezone := extractUserTimezone(spec)
 
 	vmCfg := lifecycle.VMConfig{
 		AgentID:             agentID,
@@ -627,6 +630,7 @@ func (f *Factory) assignTask(agentID string, spec *types.TaskSpec) error {
 		SynthesizedSkills:   f.synthesizedSkillsForDomain(entryDomain),
 		OriginalUserMessage: originalUserMessage,
 		UserFacing:          userFacing,
+		UserTimezone:        userTimezone,
 		OnComplete:          f.processCompletionHandler(agentID),
 	}
 
@@ -1421,6 +1425,18 @@ func extractConversationMetadata(spec *types.TaskSpec) (string, bool) {
 	return original, userFacing
 }
 
+// extractUserTimezone pulls the orchestrator-provided IANA tz out of the
+// TaskSpec metadata map. The io component detects it from the browser
+// (Intl.DateTimeFormat().resolvedOptions().timeZone) and the orchestrator
+// threads it through every task.inbound. Empty when the request was made
+// before the io frontend supported tz detection, or when detection failed.
+func extractUserTimezone(spec *types.TaskSpec) string {
+	if spec == nil || spec.Metadata == nil {
+		return ""
+	}
+	return spec.Metadata["user_timezone"]
+}
+
 // fetchPriorTurns retrieves the latest ConversationSnapshot for conversationID
 // from the Memory Component and returns the prior turns and their recorded token
 // count. Returns nil, 0 when conversationID is empty, no snapshot exists, or the
@@ -1775,6 +1791,7 @@ func (f *Factory) wakeAgent(agentID string, spec *types.TaskSpec) error {
 	userProfile := f.fetchUserProfile(spec.UserContextID, spec.TraceID)
 	priorTurns, _ := f.fetchPriorTurns(spec.ConversationID, spec.TraceID)
 	originalUserMessage, userFacing := extractConversationMetadata(spec)
+	userTimezone := extractUserTimezone(spec)
 	vmCfg := lifecycle.VMConfig{
 		AgentID:             agentID,
 		VMID:                newVMID,
@@ -1792,6 +1809,7 @@ func (f *Factory) wakeAgent(agentID string, spec *types.TaskSpec) error {
 		SynthesizedSkills:   f.synthesizedSkillsForDomain(entryDomain),
 		OriginalUserMessage: originalUserMessage,
 		UserFacing:          userFacing,
+		UserTimezone:        userTimezone,
 		OnComplete:          f.processCompletionHandler(agentID),
 	}
 	if err := f.lifecycle.Spawn(vmCfg); err != nil {

--- a/agents-component/internal/lifecycle/firecracker.go
+++ b/agents-component/internal/lifecycle/firecracker.go
@@ -395,6 +395,7 @@ func (m *firecrackerManager) configureMMDS(vm *fcVM, config VMConfig) error {
 			UserProfile:      config.UserProfile,
 			TraceID:          config.TraceID,
 			UserContextID:    config.UserContextID,
+			UserTimezone:     config.UserTimezone,
 		},
 		Env: fcGuestEnv(config),
 	}

--- a/agents-component/internal/lifecycle/lifecycle.go
+++ b/agents-component/internal/lifecycle/lifecycle.go
@@ -57,6 +57,12 @@ type VMConfig struct {
 	// for this conversation turn. Only this agent persists a conversation_snapshot.
 	UserFacing bool
 
+	// UserTimezone is the IANA tz from the user's browser (e.g.
+	// "America/Los_Angeles"). Threaded by the orchestrator through
+	// TaskSpec.Metadata["user_timezone"]. Empty falls back to UTC inside the
+	// agent's buildSystemPrompt.
+	UserTimezone string
+
 	// OnComplete is called by the process manager when the agent process exits.
 	// output holds the raw TaskOutput JSON written to stdout; exitErr is non-nil
 	// when the process exited with a non-zero status. The factory uses this to
@@ -130,6 +136,7 @@ type agentSpawnContext struct {
 
 	OriginalUserMessage string `json:"original_user_message,omitempty"`
 	UserFacing          bool   `json:"user_facing,omitempty"`
+	UserTimezone        string `json:"user_timezone,omitempty"`
 }
 
 // processEntry tracks a single running agent-process subprocess. The process
@@ -224,6 +231,7 @@ func encodeSpawnContext(config VMConfig) ([]byte, error) {
 		SynthesizedSkills:   config.SynthesizedSkills,
 		OriginalUserMessage: config.OriginalUserMessage,
 		UserFacing:          config.UserFacing,
+		UserTimezone:        config.UserTimezone,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("lifecycle: marshal spawn context: %w", err)

--- a/io/api/src/index.ts
+++ b/io/api/src/index.ts
@@ -709,7 +709,7 @@ app.post('/api/chat', async (c) => {
   const effectiveUserId = activeUserId(c)
   if (!effectiveUserId) return userIdRequired(c)
   const body = (await c.req.json()) as SendMessageRequest;
-  const { taskId, content, conversationHistory, conversationId, required_skill_domains } = body as SendMessageRequest & { required_skill_domains?: string[] };
+  const { taskId, content, conversationHistory, conversationId, required_skill_domains, user_timezone } = body as SendMessageRequest & { required_skill_domains?: string[]; user_timezone?: string };
   const traceId = c.get('traceId') as string | undefined;
   if (taskId) c.set('taskId', taskId)
   if (conversationId) c.set('conversationId', conversationId)
@@ -779,6 +779,7 @@ app.post('/api/chat', async (c) => {
         trace_id: traceId,
         conversation_id: conversationId,
         required_skill_domains,
+        user_timezone,
       })
       awaitingOrchestratorChat = true
       logFromContext(c, 'info', 'nats', 'forwarded chat message to orchestrator on user_task subject', {

--- a/io/api/src/nats/client.ts
+++ b/io/api/src/nats/client.ts
@@ -66,6 +66,11 @@ export interface UserTaskPayload {
   conversation_id?: string
   /** W3C trace_id (32 hex) — forwarded on the wire envelope for orchestrator logs */
   trace_id?: string
+  /** IANA tz from the user's browser (Intl.DateTimeFormat().resolvedOptions().timeZone).
+   *  Threaded by the orchestrator into every subtask spawn so the agent's
+   *  buildSystemPrompt can localise the wall-clock and instruct the LLM to
+   *  report times in the user's tz instead of UTC. */
+  user_timezone?: string
 }
 
 export interface IONatsClient {
@@ -247,6 +252,7 @@ export function createNatsClient(config: NatsConfig): IONatsClient | null {
         callback_topic: task.callback_topic ?? callbackTopicForTask(task.task_id),
         user_context_id: task.user_context_id,
         ...(task.conversation_id ? { conversation_id: task.conversation_id } : {}),
+        ...(task.user_timezone ? { user_timezone: task.user_timezone } : {}),
       }
       const envelope = buildEnvelope('user_task', task.task_id, natsPayload, task.trace_id)
       const data = new TextEncoder().encode(JSON.stringify(envelope))

--- a/io/surfaces/web/src/api/orchestrator.ts
+++ b/io/surfaces/web/src/api/orchestrator.ts
@@ -181,6 +181,16 @@ export async function* streamOrchestratorReply(
 ): AsyncGenerator<string, void, unknown> {
   let res: Response
   try {
+    // Detect the browser's IANA tz so the agent can localise its wall-clock
+    // and report event/calendar times in the user's timezone instead of UTC.
+    // Falls back to undefined if the browser doesn't expose Intl (very old);
+    // the api/orchestrator/agent chain treats absence as "use UTC".
+    let userTimezone: string | undefined
+    try {
+      userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+    } catch {
+      userTimezone = undefined
+    }
     res = await fetch(buildApiUrl('/api/chat'), {
       method: 'POST',
       headers: {
@@ -194,6 +204,7 @@ export async function* streamOrchestratorReply(
         content: userContent,
         conversationHistory,
         conversationId,
+        ...(userTimezone ? { user_timezone: userTimezone } : {}),
       }),
     })
   } catch (err) {

--- a/orchestrator/internal/dispatcher/dispatcher.go
+++ b/orchestrator/internal/dispatcher/dispatcher.go
@@ -302,6 +302,7 @@ func (d *Dispatcher) HandleInboundTask(ctx context.Context, task types.UserTask)
 		UserContextID:        task.UserContextID,
 		ConversationID:       task.ConversationID,
 		IdempotencyWindow:    idempotencyWindow,
+		UserTimezone:         task.UserTimezone,
 		Payload:              task.Payload,
 		StateHistory: []types.StateEvent{
 			{State: types.StateReceived, Timestamp: now, NodeID: d.cfg.NodeID},
@@ -391,6 +392,7 @@ func (d *Dispatcher) HandleInboundTask(ctx context.Context, task types.UserTask)
 		ConversationID:  task.ConversationID,
 		ProgressSummary: "Generating execution plan",
 		TraceID:         ts.TraceID,
+		UserTimezone:    task.UserTimezone,
 	}
 
 	{
@@ -710,6 +712,7 @@ type agentSpawnContext struct {
 	UserContextID  string
 	ConversationID string
 	TraceID        string
+	UserTimezone   string
 	Depth          int
 }
 
@@ -789,6 +792,7 @@ func (d *Dispatcher) HandleAgentSpawnRequest(ctx context.Context, req types.Agen
 		ConversationID:  childCtx.ConversationID,
 		ProgressSummary: "Running delegated child agent task",
 		TraceID:         childCtx.TraceID,
+		UserTimezone:    childCtx.UserTimezone,
 	}
 	if spec.TraceID == "" {
 		spec.TraceID = observability.TraceIDFrom(ctx)
@@ -865,6 +869,7 @@ func agentSpawnContextFromTaskState(ts *types.TaskState, depth int) agentSpawnCo
 		UserContextID:  ts.UserContextID,
 		ConversationID: ts.ConversationID,
 		TraceID:        ts.TraceID,
+		UserTimezone:   ts.UserTimezone,
 		Depth:          depth,
 	}
 }

--- a/orchestrator/internal/executor/executor.go
+++ b/orchestrator/internal/executor/executor.go
@@ -540,6 +540,7 @@ func (e *PlanExecutor) dispatchSubtask(ctx context.Context, exec *planExecution,
 		UserContextID:  exec.ts.UserContextID,
 		ConversationID: exec.ts.ConversationID,
 		TraceID:        exec.ts.TraceID,
+		UserTimezone:   exec.ts.UserTimezone,
 	}
 
 	if err := e.gw.PublishTaskSpec(ctx, spec); err != nil {

--- a/orchestrator/internal/gateway/gateway.go
+++ b/orchestrator/internal/gateway/gateway.go
@@ -1290,6 +1290,9 @@ func buildAgentMetadata(spec types.TaskSpec) map[string]string {
 	if spec.ProgressSummary != "" {
 		meta["progress_summary"] = spec.ProgressSummary
 	}
+	if spec.UserTimezone != "" {
+		meta["user_timezone"] = spec.UserTimezone
+	}
 	for k, v := range spec.Metadata {
 		meta[k] = v
 	}

--- a/orchestrator/internal/recovery/manager.go
+++ b/orchestrator/internal/recovery/manager.go
@@ -268,6 +268,7 @@ func (m *Manager) attemptRecovery(ctx context.Context, ts *types.TaskState, reas
 		UserContextID:        recoveredState.UserContextID,
 		ProgressSummary:      fmt.Sprintf("Recovery attempt %d", recoveredState.RetryCount),
 		TraceID:              recoveredState.TraceID,
+		UserTimezone:         recoveredState.UserTimezone,
 	}
 
 	if err := m.gateway.PublishTaskSpec(ctx, spec); err != nil {

--- a/orchestrator/internal/types/messages.go
+++ b/orchestrator/internal/types/messages.go
@@ -77,6 +77,11 @@ type TaskSpec struct {
 	ProgressSummary      string            `json:"progress_summary,omitempty"` // Set on recovery re-dispatch
 	// TraceID is W3C trace_id (32 hex); empty uses orchestrator_task_ref on the agent wire payload.
 	TraceID string `json:"trace_id,omitempty"`
+	// UserTimezone is the IANA tz name from the originating UserTask. Carried
+	// alongside UserContextID/ConversationID so every subtask spawn for a given
+	// user request can inject the same wall-clock localisation into the agent's
+	// system prompt. Surfaced to the agent wire as Metadata["user_timezone"].
+	UserTimezone string `json:"user_timezone,omitempty"`
 }
 
 // ─── Task Accepted / Result ───────────────────────────────────────────────────

--- a/orchestrator/internal/types/task.go
+++ b/orchestrator/internal/types/task.go
@@ -141,6 +141,7 @@ type TaskState struct {
 	UserContextID        string          `json:"user_context_id,omitempty"`
 	ConversationID       string          `json:"conversation_id,omitempty"` // Stable ID linking tasks in the same multi-turn conversation
 	IdempotencyWindow    int             `json:"idempotency_window_seconds"`
+	UserTimezone         string          `json:"user_timezone,omitempty"`   // IANA tz from user's browser; threaded into every dispatch so all subtasks share it
 }
 
 // ─── UserTask ─────────────────────────────────────────────────────────────────
@@ -159,6 +160,10 @@ type UserTask struct {
 	IdempotencyWindow    int             `json:"idempotency_window_seconds,omitempty"` // Default 300
 	// TraceID is W3C trace_id (32 hex) from I/O; also accepted on the inbound MessageEnvelope.trace_id.
 	TraceID string `json:"trace_id,omitempty"`
+	// UserTimezone is the IANA tz name detected from the user's browser
+	// (Intl.DateTimeFormat().resolvedOptions().timeZone). Empty when the
+	// io surface is older than tz-detection support; agents fall back to UTC.
+	UserTimezone string `json:"user_timezone,omitempty"`
 }
 
 // ─── Execution Plan & Subtask Types (NEW in v3.0) ─────────────────────────────


### PR DESCRIPTION
## Summary

Closes the UTC-only-replies rough edge called out in `docs/E1-handoff.md`. Agents now receive the user's IANA tz (detected via `Intl.DateTimeFormat().resolvedOptions().timeZone` in the browser) and report times in that tz instead of echoing the raw `...Z` strings from the iCal feed.

## What changed

- **io frontend** (`orchestrator.ts`): detects browser tz, adds `user_timezone` to `/api/chat` body.
- **io api** (`index.ts`, `nats/client.ts`): forwards `user_timezone` onto the NATS `user_task` envelope.
- **orchestrator** (`types/task.go`, `types/messages.go`, `dispatcher.go`, `executor.go`, `recovery/manager.go`, `gateway.go`): adds `UserTimezone` to `UserTask` / `TaskState` / `TaskSpec`, threads it through planner, subtask, agent-spawn-child, and recovery dispatch paths. `buildAgentMetadata` projects it onto the agent wire as `Metadata["user_timezone"]` so all subtask spawns inherit the same tz.
- **agents-component** (`factory/factory.go`, `lifecycle/lifecycle.go`, `lifecycle/firecracker.go`): `extractUserTimezone(spec)` helper reads metadata; threaded through `VMConfig` → `agentSpawnContext` → process binary stdin / Firecracker MMDS.
- **agent-process** (`main.go`, `loop.go`): adds `SpawnContext.UserTimezone`; `buildSystemPrompt` formats the wall-clock header in the user's tz and adds an explicit "TIME HANDLING RULES" block with a worked example (the soft "express times in this tz" hint alone wasn't enough — the model would still echo the raw `Z` string from the calendar tool result).
- **agent-process** (`main.go`): blank-imports `_ "time/tzdata"` so `time.LoadLocation` works inside the alpine runtime image, which doesn't ship `/usr/share/zoneinfo`. Without this the prompt silently fell back to UTC even when the browser sent a valid IANA name. ~450KB binary cost — worth it to keep the runtime image minimal.

Empty `user_timezone` (older io clients, or detection failure) falls back to UTC at every layer — no behaviour change for existing callers.

## Test plan

- [x] `go test ./cmd/agent-process/` (agents-component) — passing
- [x] `go test ./internal/dispatcher/ ./internal/gateway/` (orchestrator) — passing
- [x] Manual end-to-end:
  - Verified `user_timezone: "America/Los_Angeles"` flows through io api log → aegis-agents `task.inbound` metadata → `agent-process` SpawnContext → `buildSystemPrompt` header.
  - Asked *"What is my next calendar event?"* — agent now reports e.g. *"E1 timezone test event on Wednesday, May 13, 2026 at 10:32 PM PDT"* (was *"...starts at 5:32 AM UTC"*).
- [ ] Sanity check from a tz other than `America/Los_Angeles` (e.g. `Europe/London`) before merging.
- [ ] Confirm older io clients that don't send `user_timezone` still get UTC replies (graceful fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)